### PR TITLE
Stabilize OAuth redirect URI generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,6 +143,7 @@ jobs:
           GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
+          PUBLIC_BASE_URL: ${{ vars.PUBLIC_BASE_URL }}
           AUTH_MODE: ${{ vars.AUTH_MODE }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
@@ -164,6 +165,7 @@ jobs:
             exit 1
           fi
 
+          public_base_url="${PUBLIC_BASE_URL:-${AZURE_WEBAPP_URL:-}}"
           image_name="ghcr.io/${GITHUB_REPOSITORY}:${DEPLOY_SHA}"
           persistent_database_url="${DATABASE_URL:-sqlite:////home/site/data/stockmgr.db}"
 
@@ -184,6 +186,7 @@ jobs:
           )
 
           [[ -n "${SECRET_KEY:-}" ]] && app_settings+=("SECRET_KEY=$SECRET_KEY")
+          [[ -n "${public_base_url:-}" ]] && app_settings+=("PUBLIC_BASE_URL=$public_base_url")
           [[ -n "${AUTH_MODE:-}" ]] && app_settings+=("AUTH_MODE=$AUTH_MODE")
           [[ -n "${GOOGLE_CLIENT_ID:-}" ]] && app_settings+=("GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID")
           [[ -n "${GOOGLE_CLIENT_SECRET:-}" ]] && app_settings+=("GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET")

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Set **Repository Variables** (`Settings -> Secrets and variables -> Actions -> V
 - `AZURE_APPSERVICE_PLAN` = `asp-stockmgr-prod`
 - `AZURE_WEBAPP_NAME` = `stockmgr-prod-<unique-suffix>`
 - Optional: `AZURE_APPSERVICE_PLAN_RESOURCE_GROUP` (if different from web app RG)
-- Optional app config: `AUTH_MODE`, `CALENDAR_PROVIDER`, `RENEWAL_WINDOW_DAYS`, `ADMIN_EMAILS`, `EXCEL_API_USER_EMAIL`, `DATABASE_URL`
+- Optional app config: `AUTH_MODE`, `CALENDAR_PROVIDER`, `RENEWAL_WINDOW_DAYS`, `ADMIN_EMAILS`, `EXCEL_API_USER_EMAIL`, `DATABASE_URL`, `PUBLIC_BASE_URL`
 - For Gmail + Outlook login, set `AUTH_MODE=oauth`.
 - If `DATABASE_URL` is not set, deploy workflow defaults to persistent App Service storage: `sqlite:////home/site/data/stockmgr.db`
 
@@ -259,14 +259,14 @@ Set **Repository Secrets**:
 ### 3.1) Configure OAuth providers for gmail.com and outlook.com
 1. **Google (gmail.com)**:
    - Google Cloud Console -> `APIs & Services` -> `Credentials` -> create an **OAuth 2.0 Client ID** (Web application).
-   - Authorized redirect URI:
+   - Authorized redirect URI (must match exactly, including `https`):
      - `https://<AZURE_WEBAPP_NAME>.azurewebsites.net/auth/google/callback`
    - Save values to GitHub secrets: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`.
 
 2. **Microsoft (outlook.com)**:
    - Azure Portal -> `Microsoft Entra ID` -> `App registrations` -> create app.
    - Supported account types: **Accounts in any organizational directory and personal Microsoft accounts**.
-   - Add Web redirect URI:
+   - Add Web redirect URI (must match exactly, including `https`):
      - `https://<AZURE_WEBAPP_NAME>.azurewebsites.net/auth/microsoft/callback`
    - Save values to GitHub secrets: `MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET`.
 
@@ -312,6 +312,7 @@ Set **Repository Secrets**:
 - Smoke test fails: inspect `scripts/azure/smoke_test.sh` expectations (`/health`, manifest, Excel API auth behavior).
 - Manual re-run of an old workflow run: this is now blocked for `push` events to prevent stale commit rollback deployments.
 - OAuth buttons missing: ensure `AUTH_MODE` is not `dev` and required OAuth secrets are set in GitHub (`GOOGLE_*`, `MICROSOFT_*`) with correct callback URLs.
+- `Error 400: redirect_uri_mismatch` (Google): verify Google redirect URI exactly matches `/auth/google/callback` and set `PUBLIC_BASE_URL` (GitHub Actions variable) to your public HTTPS app URL so runtime-generated callback URIs are stable behind Azure proxying.
 - Data disappears after redeploy: confirm app settings include `WEBSITES_ENABLE_APP_SERVICE_STORAGE=true` and `DATABASE_URL` points to `/home/...` (for example `sqlite:////home/site/data/stockmgr.db`), not a path inside the container image filesystem.
 
 ### Local script dry-run (optional)

--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
 
     app_name: str = "stockmgr"
     app_version: str = "dev"
+    public_base_url: str | None = None
     environment: Literal["development", "test", "production"] = "development"
     database_url: str = "sqlite:///./stockmgr.db"
     secret_key: str = "change-me-for-production"

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import httpx
 from authlib.integrations.starlette_client import OAuth
@@ -462,8 +462,56 @@ async def oauth_start(request: Request, provider: str):
     client = oauth.create_client(provider)
     if not client:
         raise HTTPException(status_code=404, detail=f"OAuth provider '{provider}' is unavailable.")
-    redirect_uri = request.url_for("oauth_callback", provider=provider)
-    return await client.authorize_redirect(request, str(redirect_uri))
+    redirect_uri = _oauth_callback_redirect_uri(request, provider)
+    return await client.authorize_redirect(request, redirect_uri)
+
+
+def _oauth_callback_redirect_uri(request: Request, provider: str) -> str:
+    callback_uri = str(request.url_for("oauth_callback", provider=provider))
+    return _build_oauth_redirect_uri(
+        callback_uri=callback_uri,
+        public_base_url=settings.public_base_url,
+        forwarded_proto=request.headers.get("x-forwarded-proto"),
+    )
+
+
+def _build_oauth_redirect_uri(
+    callback_uri: str,
+    public_base_url: str | None,
+    forwarded_proto: str | None,
+) -> str:
+    parsed_callback = urlsplit(callback_uri)
+    configured_base = (public_base_url or "").strip()
+    if configured_base:
+        if "://" not in configured_base:
+            configured_base = f"https://{configured_base}"
+        parsed_base = urlsplit(configured_base)
+        if parsed_base.scheme and parsed_base.netloc:
+            base_path = parsed_base.path.rstrip("/")
+            callback_path = parsed_callback.path
+            combined_path = f"{base_path}{callback_path}" if base_path else callback_path
+            return urlunsplit(
+                (
+                    parsed_base.scheme,
+                    parsed_base.netloc,
+                    combined_path,
+                    parsed_callback.query,
+                    parsed_callback.fragment,
+                )
+            )
+
+    normalized_forwarded_proto = (forwarded_proto or "").split(",")[0].strip().lower()
+    if normalized_forwarded_proto == "https" and parsed_callback.scheme != "https":
+        return urlunsplit(
+            (
+                "https",
+                parsed_callback.netloc,
+                parsed_callback.path,
+                parsed_callback.query,
+                parsed_callback.fragment,
+            )
+        )
+    return callback_uri
 
 
 @app.get("/auth/{provider}/callback")

--- a/tests/test_oauth_redirect_uri.py
+++ b/tests/test_oauth_redirect_uri.py
@@ -1,0 +1,31 @@
+from app.main import _build_oauth_redirect_uri
+
+
+def test_oauth_redirect_uri_prefers_configured_public_base_url():
+    callback_uri = "http://10.0.0.4:8000/auth/google/callback"
+    redirect_uri = _build_oauth_redirect_uri(
+        callback_uri=callback_uri,
+        public_base_url="https://stockmgr-prod-01.azurewebsites.net",
+        forwarded_proto=None,
+    )
+    assert redirect_uri == "https://stockmgr-prod-01.azurewebsites.net/auth/google/callback"
+
+
+def test_oauth_redirect_uri_honors_public_base_path_prefix():
+    callback_uri = "http://127.0.0.1:8000/auth/microsoft/callback"
+    redirect_uri = _build_oauth_redirect_uri(
+        callback_uri=callback_uri,
+        public_base_url="https://example.com/stockmgr",
+        forwarded_proto=None,
+    )
+    assert redirect_uri == "https://example.com/stockmgr/auth/microsoft/callback"
+
+
+def test_oauth_redirect_uri_upgrades_http_when_forwarded_proto_is_https():
+    callback_uri = "http://stockmgr-prod-01.azurewebsites.net/auth/google/callback"
+    redirect_uri = _build_oauth_redirect_uri(
+        callback_uri=callback_uri,
+        public_base_url=None,
+        forwarded_proto="https",
+    )
+    assert redirect_uri == "https://stockmgr-prod-01.azurewebsites.net/auth/google/callback"


### PR DESCRIPTION
Use PUBLIC_BASE_URL and HTTPS proxy fallback when building OAuth callback URLs, and wire PUBLIC_BASE_URL into Azure app settings during deploy.