### PR TITLE
Fix Microsoft OAuth callback invalid iss claim error

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Set **Repository Secrets**:
 - OAuth buttons missing: ensure `AUTH_MODE` is not `dev` and required OAuth secrets are set in GitHub (`GOOGLE_*`, `MICROSOFT_*`) with correct callback URLs.
 - `Error 400: redirect_uri_mismatch` (Google): verify Google redirect URI exactly matches `/auth/google/callback` and set `PUBLIC_BASE_URL` (GitHub Actions variable) to your public HTTPS app URL so runtime-generated callback URIs are stable behind Azure proxying.
 - Microsoft callback `server_error`: the app now redirects safely back to `/login` with an OAuth message. If it appears, verify Microsoft Entra app registration redirect URI and API permissions/consent (`User.Read`, calendar scopes).
+- Microsoft callback with `code` followed by internal error: issuer-claim validation is now relaxed for Microsoft token exchange to support tenant-specific issuer values from `/common`; callback failures now redirect to `/login` with a message instead of returning 500.
 - Data disappears after redeploy: confirm app settings include `WEBSITES_ENABLE_APP_SERVICE_STORAGE=true` and `DATABASE_URL` points to `/home/...` (for example `sqlite:////home/site/data/stockmgr.db`), not a path inside the container image filesystem.
 
 ### Local script dry-run (optional)

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from urllib.parse import urlencode, urlsplit, urlunsplit
 import httpx
 from authlib.integrations.base_client.errors import OAuthError
 from authlib.integrations.starlette_client import OAuth
+from authlib.jose.errors import JoseError
 from fastapi import Depends, FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -578,8 +579,13 @@ async def oauth_callback(
         message_key = _oauth_message_from_error(oauth_error)
         return RedirectResponse(f"/login?m={message_key}", status_code=303)
 
+    token_kwargs: dict[str, Any] = {}
+    if provider == "microsoft":
+        # Microsoft /common may return tenant-specific issuers; accept token claims
+        # without strict issuer matching and rely on subsequent Graph profile lookup.
+        token_kwargs["claims_options"] = {}
     try:
-        token = await client.authorize_access_token(request)
+        token = await client.authorize_access_token(request, **token_kwargs)
     except OAuthError as exc:
         logger.warning(
             "OAuth token exchange failed for provider %s: %s (%s)",
@@ -589,6 +595,9 @@ async def oauth_callback(
         )
         message_key = _oauth_message_from_error(exc.error)
         return RedirectResponse(f"/login?m={message_key}", status_code=303)
+    except JoseError as exc:
+        logger.warning("OAuth ID token validation failed for provider %s: %s", provider, exc)
+        return RedirectResponse("/login?m=oauth-provider-error", status_code=303)
     userinfo = token.get("userinfo")
     if not userinfo:
         if provider == "google":

--- a/tests/test_oauth_error_handling.py
+++ b/tests/test_oauth_error_handling.py
@@ -1,9 +1,31 @@
 from authlib.integrations.base_client.errors import OAuthError
+from authlib.jose.errors import InvalidClaimError
 
 
 class _OAuthFailingClient:
-    async def authorize_access_token(self, request):
+    async def authorize_access_token(self, request, **kwargs):
         raise OAuthError(error="server_error", description="upstream error")
+
+
+class _JoseFailingClient:
+    async def authorize_access_token(self, request, **kwargs):
+        raise InvalidClaimError("iss")
+
+
+class _CapturingClient:
+    def __init__(self):
+        self.kwargs = None
+
+    async def authorize_access_token(self, request, **kwargs):
+        self.kwargs = kwargs
+        return {
+            "access_token": "test-access",
+            "userinfo": {
+                "id": "provider-subject-1",
+                "email": "new-oauth-user@example.com",
+                "name": "New OAuth User",
+            },
+        }
 
 
 def test_oauth_callback_redirects_when_provider_returns_error_query(client, monkeypatch):
@@ -37,3 +59,23 @@ def test_oauth_callback_maps_access_denied_to_cancelled_message(client, monkeypa
 
     assert response.status_code == 303
     assert response.headers["location"] == "/login?m=oauth-cancelled"
+
+
+def test_oauth_callback_redirects_when_id_token_claim_validation_fails(client, monkeypatch):
+    monkeypatch.setattr("app.main.oauth.create_client", lambda provider: _JoseFailingClient())
+
+    response = client.get("/auth/microsoft/callback?state=test-state", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login?m=oauth-provider-error"
+
+
+def test_oauth_callback_uses_relaxed_claims_options_for_microsoft(client, monkeypatch):
+    captured = _CapturingClient()
+    monkeypatch.setattr("app.main.oauth.create_client", lambda provider: captured)
+
+    response = client.get("/auth/microsoft/callback?state=test-state", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/login?m=login-pending-approval"
+    assert captured.kwargs == {"claims_options": {}}


### PR DESCRIPTION
Addresses callback failures with authorization code flow by relaxing Microsoft ID-token issuer claim validation and guarding JOSE claim-validation errors, with regression tests.