### PR TITLE
Enable Continente provider in active defaults

### DIFF
--- a/.github/project-requirements.md
+++ b/.github/project-requirements.md
@@ -96,7 +96,7 @@ The application must ship with this default provider order:
 - Default policy: do not rely on retailer scraping as a primary source.
 - Only enable retailer connectors through explicit configuration and legal/compliance review of terms of use.
 - Any retailer connector must be isolated behind the provider abstraction layer so it can be disabled without affecting core flows.
-- Current implementation status: `continente_pt` barcode search scraping support is available in the provider layer, but disabled by default pending explicit enablement.
+- Current implementation status: `continente_pt` barcode search scraping support is available and active in the default provider configuration.
 
 ## Open refinement areas
 - OAuth providers and account model

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ TELEGRAM_REQUIRE_PRIVATE_CHAT=true
 ```
 
 Barcode provider behavior is driven by `config/barcode-providers.default.json`.
-The `continente_pt` connector is implemented with barcode search + product-page scraping,
-but remains disabled by default. Enable it explicitly in provider config after legal/compliance review.
+The `continente_pt` connector is implemented with barcode search + product-page scraping
+and is active in the default lookup chain configuration.
 
 ## Excel datasource API (read + write)
 - Authentication: set `X-Excel-Api-Key` header (or `X-API-Key`) to `EXCEL_API_KEY`.

--- a/config/barcode-providers.default.json
+++ b/config/barcode-providers.default.json
@@ -215,7 +215,7 @@
     "continente_pt": {
       "displayName": "Continente Portugal Connector",
       "kind": "retailer",
-      "enabled": false,
+      "enabled": true,
       "defaultCountryPriority": [
         "PT"
       ],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,6 @@ def test_provider_config_uses_portugal_first():
     assert config["lookup"]["countryPriority"][0] == "PT"
     assert config["lookup"]["chains"]["food"][0] == "open_food_facts"
     assert "continente_pt" in config["lookup"]["chains"]["food"]
-    assert config["providers"]["continente_pt"]["enabled"] is False
+    assert config["providers"]["continente_pt"]["enabled"] is True
     assert config["providers"]["continente_pt"]["capabilities"]["supportsBarcodeLookup"] is True
     assert config["providers"]["auchan_pt"]["enabled"] is False


### PR DESCRIPTION
## Summary
- enable continente_pt in default provider config so it is active in lookup flows
- keep provider in active food-chain list and align docs/requirements/test expectations
- validate barcode 5601326000122 with active provider chain output

## Validation
- python -m ruff check .
- python -m pytest
- barcode test output: active_food_providers and lookup result