### PR TITLE
fix: handle path separators in product names causing 500

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote as url_quote
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import httpx
@@ -76,6 +77,7 @@ app.add_middleware(
 )
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+templates.env.filters["urlencode_path"] = lambda v: url_quote(str(v), safe="")
 
 oauth = OAuth()
 if settings.google_client_id and settings.google_client_secret:
@@ -915,12 +917,14 @@ def search_item_from_home(
             .order_by(StockItem.expiry_date, StockItem.updated_at.desc())
         ).first()
         if barcode_match:
-            detail_url = request.url_for(
-                "product_detail",
-                item_type=barcode_match.item_type,
-                product_name=barcode_match.name,
+            detail_url = (
+                str(request.base_url).rstrip("/")
+                + "/products/by-name/"
+                + url_quote(barcode_match.item_type, safe="")
+                + "/"
+                + url_quote(barcode_match.name, safe="")
             )
-            return RedirectResponse(str(detail_url), status_code=303)
+            return RedirectResponse(detail_url, status_code=303)
 
         new_item_url = f"{request.url_for('item_new')}?{urlencode({'barcode': barcode_value})}"
         return RedirectResponse(new_item_url, status_code=303)
@@ -944,12 +948,14 @@ def search_item_from_home(
         ).first()
 
     if name_match:
-        detail_url = request.url_for(
-            "product_detail",
-            item_type=name_match.item_type,
-            product_name=name_match.name,
+        detail_url = (
+            str(request.base_url).rstrip("/")
+            + "/products/by-name/"
+            + url_quote(name_match.item_type, safe="")
+            + "/"
+            + url_quote(name_match.name, safe="")
         )
-        return RedirectResponse(str(detail_url), status_code=303)
+        return RedirectResponse(detail_url, status_code=303)
 
     new_item_url = f"{request.url_for('item_new')}?{urlencode({'name': search_value})}"
     return RedirectResponse(new_item_url, status_code=303)
@@ -1335,7 +1341,7 @@ def renewal_plan(
     )
 
 
-@app.get("/products/by-name/{item_type}/{product_name}")
+@app.get("/products/by-name/{item_type}/{product_name:path}")
 def product_detail(
     item_type: str,
     product_name: str,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -70,7 +70,7 @@
       <tbody>
       {% for item in items %}
         <tr>
-          <td><a class="text-decoration-none" href="{{ url_for('product_detail', item_type=item.item_type, product_name=item.name) }}">{{ item.name }}</a></td>
+          <td><a class="text-decoration-none" href="/products/by-name/{{ item.item_type | urlencode_path }}/{{ item.name | urlencode_path }}">{{ item.name }}</a></td>
           <td>{{ item.item_type }}</td>
           <td>{{ item.barcode or "-" }}</td>
           <td>{{ item.batch_code or "-" }}</td>

--- a/app/templates/stock_views.html
+++ b/app/templates/stock_views.html
@@ -35,7 +35,7 @@
         <tbody>
           {% for row in overall_rows %}
           <tr>
-            <td><a class="text-decoration-none" href="{{ url_for('product_detail', item_type=row[1], product_name=row[0]) }}">{{ row[0] }}</a></td>
+            <td><a class="text-decoration-none" href="/products/by-name/{{ row[1] | urlencode_path }}/{{ row[0] | urlencode_path }}">{{ row[0] }}</a></td>
             <td>{{ row[1] }}</td>
             <td>{{ row[2] }}</td>
           </tr>
@@ -66,7 +66,7 @@
         <tbody>
           {% for row in location_rows %}
           <tr>
-            <td><a class="text-decoration-none" href="{{ url_for('product_detail', item_type=row.item_type, product_name=row.name) }}">{{ row.name }}</a></td>
+            <td><a class="text-decoration-none" href="/products/by-name/{{ row.item_type | urlencode_path }}/{{ row.name | urlencode_path }}">{{ row.name }}</a></td>
             <td>{{ row.item_type }}</td>
             <td>{{ row.location }}</td>
             <td>{{ row.quantity }}</td>
@@ -100,7 +100,7 @@
         <tbody>
           {% for row in validity_rows %}
           <tr>
-            <td><a class="text-decoration-none" href="{{ url_for('product_detail', item_type=row[1], product_name=row[0]) }}">{{ row[0] }}</a></td>
+            <td><a class="text-decoration-none" href="/products/by-name/{{ row[1] | urlencode_path }}/{{ row[0] | urlencode_path }}">{{ row[0] }}</a></td>
             <td>{{ row[1] }}</td>
             <td>{{ row[2] }}</td>
             <td>{{ row[3] }}</td>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -789,3 +789,44 @@ def test_excel_api_update_and_upsert(client):
     assert body["updated"] == 1
     assert body["created"] == 1
     assert len(body["rows"]) == 2
+
+
+def test_home_page_with_slash_in_product_name(client):
+    """Home page must render without 500 when a product name contains '/'."""
+    client.post(
+        "/api/items",
+        json={
+            "barcode": "5600000000099",
+            "name": "Olive/Oil",
+            "item_type": "food",
+            "storage_location": "Pantry",
+            "expiry_date": "2030-06-01",
+            "quantity": 1,
+            "unidose_per_pack": 1,
+        },
+    )
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Olive/Oil" in response.text
+
+
+def test_product_detail_with_slash_in_name(client):
+    """Product detail page resolves correctly for names containing '/'."""
+    from urllib.parse import quote
+
+    client.post(
+        "/api/items",
+        json={
+            "barcode": "5600000000098",
+            "name": "Beans/Legumes",
+            "item_type": "food",
+            "storage_location": "Pantry",
+            "expiry_date": "2030-07-01",
+            "quantity": 2,
+            "unidose_per_pack": 1,
+        },
+    )
+    encoded = quote("Beans/Legumes", safe="")
+    response = client.get(f"/products/by-name/food/{encoded}")
+    assert response.status_code == 200
+    assert "Beans/Legumes" in response.text


### PR DESCRIPTION
Fix AssertionError on home page when product names contain slashes. Added urlencode_path Jinja2 filter, replaced url_for calls, changed route to path-type parameter. 81 tests pass (+2 regression tests).