### PR TITLE
fix: prevent auto-submit loop on barcode lookup (issue #57)

### DIFF
--- a/app/templates/item_form.html
+++ b/app/templates/item_form.html
@@ -661,9 +661,11 @@
     }
 
     // Auto-submit barcode lookup if pre-filled on page load (issue #57)
+    // Only trigger if no lookup result yet — prevents infinite reload loop
     const lookupInput = document.getElementById("lookup-barcode-input");
     const lookupForm = document.getElementById("barcode-lookup-form");
-    if (lookupInput && lookupForm && lookupInput.value.trim()) {
+    const lookupAlreadyDone = {{ "true" if lookup and lookup.found else "false" }};
+    if (lookupInput && lookupForm && lookupInput.value.trim() && !lookupAlreadyDone) {
       // Small delay to allow page to fully render
       setTimeout(() => lookupForm.requestSubmit(), 100);
     }


### PR DESCRIPTION
Closes #57

Fix for the infinite reload loop: only auto-submit the barcode lookup form when no lookup result exists yet. Uses a server-rendered Jinja2 flag (lookupAlreadyDone) so the JS skips the auto-submit on subsequent page loads.