### PR TITLE
fix: CSRF token suppressed by lookup overlay (regression)

### DIFF
--- a/app/templates/item_form.html
+++ b/app/templates/item_form.html
@@ -735,7 +735,7 @@
     function showOverlay() {
       overlay.classList.remove("d-none");
       // Disable all form inputs while searching
-      document.querySelectorAll("form input, form select, form textarea, form button")
+      document.querySelectorAll("form input:not([type=hidden]), form select, form textarea, form button")
         .forEach(el => { el.disabled = true; });
       // Cycle through provider names as visual progress cue
       let idx = 0;


### PR DESCRIPTION
Regression from #73: `showOverlay()` was disabling all form inputs including `[type=hidden]`, which prevented the `_csrf_token` from being submitted, causing a CSRF mismatch error on every barcode search.

Fix: exclude `[type=hidden]` inputs from the disable selector.