### PR TITLE
fix: overlay must not disable form inputs

### DIFF
--- a/app/templates/item_form.html
+++ b/app/templates/item_form.html
@@ -734,9 +734,7 @@
 
     function showOverlay() {
       overlay.classList.remove("d-none");
-      // Disable all form inputs while searching
-      document.querySelectorAll("form input:not([type=hidden]), form select, form textarea, form button")
-        .forEach(el => { el.disabled = true; });
+      // The overlay covers the screen — no need to disable inputs (would prevent submission)
       // Cycle through provider names as visual progress cue
       let idx = 0;
       if (providers.length && overlayProvider) {


### PR DESCRIPTION
Second regression from #73: disabling non-hidden inputs (`type=tel` barcode field) caused them to be dropped from the POST body, resulting in a 422 'Field required' error.

The overlay itself blocks user interaction visually — inputs do not need to be disabled.