### PR TITLE
fix: v1.1.1 — product detail 500, food wheel guard, unidose print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to stockmgr are documented here. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.1.1] - 2026-03-16
+
+### Fixed
+- **Product detail 500**: `LocationPlan.days` does not exist — corrected to `stock_duration_days` (#87)
+- **Food wheel 500 on mobile**: wrapped full route body in try/except with structured logging; inner chart errors also now isolated (#88)
+- **Unidose plan print**: added A4 print/PDF button with repeating table headers (#89)
+
+### Changed
+- Merged authlib security update 1.6.7 → 1.6.9 (#90)
+
 ## [1.1.0] - 2026-03-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stockmgr
 
-![Version](https://img.shields.io/badge/version-1.1.0-blue)
+![Version](https://img.shields.io/badge/version-1.1.1-blue)
 
 Web MVP to manage SHTF stock inventorywith OAuth-capable authentication, barcode-assisted item entry, CSV/XLSX import, renewal-date calendar sync, and configurable product-information providers.
 

--- a/app/main.py
+++ b/app/main.py
@@ -1360,60 +1360,71 @@ def food_wheel_page(
         return maybe_user
     user = maybe_user
 
-    # All locations for filter dropdown (unfiltered)
-    all_location_rows = session.exec(
-        select(StockItem.storage_location).distinct()
-    ).all()
-    all_locations: list[str] = sorted(loc for loc in all_location_rows if loc)
+    import logging as _logging
+    _fw_log = _logging.getLogger("stockmgr.food_wheel")
 
-    query = select(
-        StockItem.food_group,
-        StockItem.storage_location,
-        StockItem.quantity,
-        StockItem.unidose_per_pack,
-    )
-    if location:
-        query = query.where(StockItem.storage_location == location)
-    all_rows = session.exec(query).all()
-
-    items_for_chart = [
-        {"food_group": row[0], "quantity": row[2], "unidose_per_pack": row[3]}
-        for row in all_rows
-    ]
-    lang = request.session.get("language", "pt")
-    ungrouped_count = sum(1 for item in items_for_chart if not item["food_group"])
     try:
-        chart = food_group_chart_data(items_for_chart, language=lang)
-        chart_data = [
-            {
-                "label": g["label"],
-                "color": g["color"],
-                "unidoses": int(g["actual_unidoses"]),
-                "actual_pct": g["actual_pct"],
-                "target_pct": g["target_pct"],
-                "delta": g["delta_pct"],
-            }
-            for g in chart["group_stats"]
-        ]
-        chart_total = chart["total_unidoses"]
-    except Exception:
-        import logging; logging.exception("food_wheel_page chart error")
-        chart_data = []
-        chart_total = 0
-
-    # Build plan tabs: all plans with their targeted items
-    plans = session.exec(select(LocationPlan).order_by(LocationPlan.location)).all()
-    plan_tabs = []
-    for plan in plans:
-        plan_items = session.exec(
-            select(StockItem)
-            .where(
-                StockItem.storage_location == plan.location,
-                StockItem.target_unidoses_location > 0,
-            )
-            .order_by(StockItem.name)
+        # All locations for filter dropdown (unfiltered)
+        all_location_rows = session.exec(
+            select(StockItem.storage_location).distinct()
         ).all()
-        plan_tabs.append({"plan": plan, "items": plan_items})
+        all_locations: list[str] = sorted(loc for loc in all_location_rows if loc)
+
+        query = select(
+            StockItem.food_group,
+            StockItem.storage_location,
+            StockItem.quantity,
+            StockItem.unidose_per_pack,
+        )
+        if location:
+            query = query.where(StockItem.storage_location == location)
+        all_rows = session.exec(query).all()
+
+        items_for_chart = [
+            {"food_group": row[0], "quantity": row[2], "unidose_per_pack": row[3]}
+            for row in all_rows
+        ]
+        lang = request.session.get("language", "pt")
+        ungrouped_count = sum(1 for item in items_for_chart if not item["food_group"])
+
+        try:
+            chart = food_group_chart_data(items_for_chart, language=lang)
+            chart_data = [
+                {
+                    "label": g["label"],
+                    "color": g["color"],
+                    "unidoses": int(g["actual_unidoses"]),
+                    "actual_pct": g["actual_pct"],
+                    "target_pct": g["target_pct"],
+                    "delta": g["delta_pct"],
+                }
+                for g in chart["group_stats"]
+            ]
+            chart_total = chart["total_unidoses"]
+            chart_json = json.dumps(chart_data)
+        except Exception:
+            _fw_log.exception("food_wheel chart build error")
+            chart_data = []
+            chart_total = 0
+            chart_json = "[]"
+
+        # Build plan tabs: all plans with their targeted items
+        plans = session.exec(select(LocationPlan).order_by(LocationPlan.location)).all()
+        plan_tabs = []
+        for plan in plans:
+            plan_items = session.exec(
+                select(StockItem)
+                .where(
+                    StockItem.storage_location == plan.location,
+                    StockItem.target_unidoses_location > 0,
+                )
+                .order_by(StockItem.name)
+            ).all()
+            plan_tabs.append({"plan": plan, "items": plan_items})
+
+    except Exception:
+        _fw_log.exception("food_wheel_page unexpected error")
+        raise HTTPException(status_code=500, detail="Food wheel error — check server logs.")
 
     return _render(
         request,
@@ -1421,7 +1432,7 @@ def food_wheel_page(
         {
             "user": user,
             "chart_data": chart_data if chart_total > 0 else [],
-            "chart_json": json.dumps(chart_data),
+            "chart_json": chart_json,
             "ungrouped_count": ungrouped_count,
             "all_locations": all_locations,
             "selected_location": location or "",
@@ -1532,7 +1543,7 @@ def product_detail(
         if plan:
             location_plans[loc] = {
                 "participants": plan.participants,
-                "days": plan.days,
+                "days": plan.stock_duration_days,
                 "total_meal_occasions": plan.total_meal_occasions,
             }
 

--- a/app/templates/unidose_plan.html
+++ b/app/templates/unidose_plan.html
@@ -4,6 +4,9 @@
   <div>
     <h1 class="h4 mb-0">{{ t("page.unidose_plan_title") }}</h1>
   </div>
+  <button class="btn btn-sm btn-outline-secondary d-print-none" onclick="window.print()">
+    <i class="bi bi-printer"></i> {{ t("renewal.print") }}
+  </button>
 </div>
 
 {% if message == "saved" %}
@@ -49,7 +52,17 @@
     </tbody>
   </table>
   {% if products %}
-  <button type="submit" class="btn btn-primary">{{ t("common.save_changes") }}</button>
+  <button type="submit" class="btn btn-primary d-print-none">{{ t("common.save_changes") }}</button>
   {% endif %}
 </form>
+
+<style>
+@media print {
+  @page { size: A4; margin: 15mm; }
+  .table-enhance-controls, .table-pagination { display: none !important; }
+  table { font-size: 10pt; }
+  thead { display: table-header-group; }
+  input[type="number"] { border: none; background: transparent; width: auto; padding: 0; }
+}
+</style>
 {% endblock %}

--- a/app/version.py
+++ b/app/version.py
@@ -1,4 +1,4 @@
 """Application version constants. Update APP_VERSION on every release."""
 
-APP_VERSION = "1.1.0"
+APP_VERSION = "1.1.1"
 BUILD_DATE = "2026-03-16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockmgr"
-version = "1.1.0"
+version = "1.1.1"
 description = "SHTF stock inventory management web application"
 requires-python = ">=3.12"
 


### PR DESCRIPTION
Closes #87, #88, #89

- Fix `plan.days` → `plan.stock_duration_days` (#87 — product detail 500)
- Full food_wheel_page body wrapped in try/except with structured logging (#88)
- Print/PDF button on unidose plan page with A4 CSS (#89)
- Bump to v1.1.1