### PR TITLE
fix: food wheel 500 - DetachedInstanceError on plan tabs (v1.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to stockmgr are documented here. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.1.2] - 2026-03-17
+
+### Fixed
+- **Food wheel 500 (regression)**: `plan_tabs` was passing live SQLAlchemy ORM objects to Jinja2; after the session closes, Starlette renders the template and attribute access on expired instances raises `DetachedInstanceError`. Fixed by converting `LocationPlan` and `StockItem` entries to plain dicts before returning from the route. Also renamed dict key `items` → `plan_items` to avoid collision with Python's built-in `dict.items` method, which Jinja2 resolves as a callable instead of the dict value.
+
 ## [1.1.1] - 2026-03-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stockmgr
 
-![Version](https://img.shields.io/badge/version-1.1.1-blue)
+![Version](https://img.shields.io/badge/version-1.1.2-blue)
 
 Web MVP to manage SHTF stock inventorywith OAuth-capable authentication, barcode-assisted item entry, CSV/XLSX import, renewal-date calendar sync, and configurable product-information providers.
 

--- a/app/main.py
+++ b/app/main.py
@@ -1408,7 +1408,8 @@ def food_wheel_page(
             chart_total = 0
             chart_json = "[]"
 
-        # Build plan tabs: all plans with their targeted items
+        # Build plan tabs: convert to plain dicts to avoid DetachedInstanceError
+        # (session closes before Jinja2 renders; ORM objects expire on session close)
         plans = session.exec(select(LocationPlan).order_by(LocationPlan.location)).all()
         plan_tabs = []
         for plan in plans:
@@ -1420,7 +1421,23 @@ def food_wheel_page(
                 )
                 .order_by(StockItem.name)
             ).all()
-            plan_tabs.append({"plan": plan, "items": plan_items})
+            plan_tabs.append({
+                "plan": {
+                    "location": plan.location,
+                    "participants": plan.participants,
+                    "stock_duration_days": plan.stock_duration_days,
+                    "total_meal_occasions": plan.total_meal_occasions,
+                },
+                "plan_items": [
+                    {
+                        "name": item.name,
+                        "item_type": item.item_type,
+                        "target_unidoses_location": item.target_unidoses_location,
+                        "unidose_per_pack": item.unidose_per_pack,
+                    }
+                    for item in plan_items
+                ],
+            })
 
     except Exception:
         _fw_log.exception("food_wheel_page unexpected error")

--- a/app/templates/food_wheel.html
+++ b/app/templates/food_wheel.html
@@ -63,7 +63,7 @@
           <div class="fw-semibold">{{ entry.plan.total_meal_occasions }}</div>
         </div>
       </div>
-      {% if entry.items %}
+      {% if entry.plan_items %}
       <h3 class="h6">{{ t("food_wheel.plan_items_title") }}</h3>
       <table class="table table-sm table-hover align-middle">
         <thead>
@@ -75,7 +75,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for item in entry.items %}
+          {% for item in entry.plan_items %}
           <tr>
             <td>{{ item.name }}</td>
             <td>{{ item.item_type }}</td>

--- a/app/version.py
+++ b/app/version.py
@@ -1,4 +1,4 @@
 """Application version constants. Update APP_VERSION on every release."""
 
-APP_VERSION = "1.1.1"
-BUILD_DATE = "2026-03-16"
+APP_VERSION = "1.1.2"
+BUILD_DATE = "2026-03-17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockmgr"
-version = "1.1.1"
+version = "1.1.2"
 description = "SHTF stock inventory management web application"
 requires-python = ">=3.12"
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 from sqlmodel import Session
 
 from app.db import engine
-from app.models import User
+from app.models import LocationPlan, User
 from app.schemas import BarcodeLookupResult
 
 
@@ -830,3 +830,30 @@ def test_product_detail_with_slash_in_name(client):
     response = client.get(f"/products/by-name/food/{encoded}")
     assert response.status_code == 200
     assert "Beans/Legumes" in response.text
+
+
+def test_food_wheel_with_location_plan(client):
+    """Food wheel page must not 500 when location plans exist (DetachedInstanceError regression)."""
+    # Create an item at "Cellar" with a target so the plan tab has items
+    client.post(
+        "/api/items",
+        json={
+            "barcode": "5600000099001",
+            "name": "Canned Beans",
+            "item_type": "food",
+            "storage_location": "Cellar",
+            "storage_bucket": "Shelf A",
+            "expiry_date": "2030-01-01",
+            "quantity": 5,
+            "unidose_per_pack": 2,
+            "target_unidoses_location": 20,
+        },
+    )
+    # Create a location plan for "Cellar" so plan_tabs is non-empty
+    with Session(engine) as session:
+        session.add(LocationPlan(location="Cellar", participants=2, stock_duration_days=90))
+        session.commit()
+
+    response = client.get("/food-wheel")
+    assert response.status_code == 200
+    assert "Food Wheel" in response.text


### PR DESCRIPTION
## Root cause

\plan_tabs\ was passing live SQLAlchemy ORM objects to Jinja2. Starlette renders the template **after** the DI session closes, expiring all ORM instances. Accessing any attribute on an expired detached instance raises \DetachedInstanceError\ → 500.

Only triggered in production because the production DB has LocationPlans; without plans, \plan_tabs\ is empty.

## Fix

- Convert \LocationPlan\ and \StockItem\ entries in \plan_tabs\ to plain dicts before returning from the route
- Renamed dict key \items\ → \plan_items\ (avoids Jinja2 resolving \ntry.items\ as Python's built-in \dict.items\ method)
- Updated \ood_wheel.html\ to use \ntry.plan_items- Added regression test \	est_food_wheel_with_location_plan
## Version
.1.1\ → .1.2
Closes #88