### PR TITLE
fix: item edit save button broken + dirty-check + cancel link (v1.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to stockmgr are documented here. Versions follow [Semantic Versioning](https://semver.org/).
 
-## [1.1.2] - 2026-03-17
+## [1.1.3] - 2026-03-17
+
+### Fixed
+- **Item edit "Save changes" does nothing (#93)**: nested `<form>` (image upload) inside the main form caused the browser to implicitly close the outer form at its `</form>` tag, leaving the Save button outside any form. Fixed by replacing the inner form with a `<div>` and adding `formaction`/`formmethod`/`formenctype` attributes directly on the Upload button so it submits to the correct endpoint while remaining part of the outer form.
+
+### Changed
+- **Save button dirty-check**: in edit mode the Save button is now disabled by default and only enabled once any form field value has changed, preventing accidental saves.
+- **Cancel button in edit mode**: now links back to the product detail page instead of home.
+
+
 
 ### Fixed
 - **Food wheel 500 (regression)**: `plan_tabs` was passing live SQLAlchemy ORM objects to Jinja2; after the session closes, Starlette renders the template and attribute access on expired instances raises `DetachedInstanceError`. Fixed by converting `LocationPlan` and `StockItem` entries to plain dicts before returning from the route. Also renamed dict key `items` → `plan_items` to avoid collision with Python's built-in `dict.items` method, which Jinja2 resolves as a callable instead of the dict value.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stockmgr
 
-![Version](https://img.shields.io/badge/version-1.1.2-blue)
+![Version](https://img.shields.io/badge/version-1.1.3-blue)
 
 Web MVP to manage SHTF stock inventorywith OAuth-capable authentication, barcode-assisted item entry, CSV/XLSX import, renewal-date calendar sync, and configurable product-information providers.
 

--- a/app/main.py
+++ b/app/main.py
@@ -1633,6 +1633,7 @@ def item_edit(item_id: int, request: Request, session: Session = Depends(get_ses
         product_name=item.name,
     )
     plans_map = {p.location: p.total_meal_occasions for p in session.exec(select(LocationPlan)).all()}
+    back_url = f"/products/by-name/{item.item_type}/{item.name.replace(' ', '%20')}"
     return _render(
         request,
         "item_form.html",
@@ -1645,6 +1646,7 @@ def item_edit(item_id: int, request: Request, session: Session = Depends(get_ses
             "food_groups": FOOD_GROUPS,
             "plan_locations": _plan_locations(session),
             "location_plans_json": json.dumps(plans_map),
+            "back_url": back_url,
         },
     )
 

--- a/app/templates/item_form.html
+++ b/app/templates/item_form.html
@@ -147,12 +147,14 @@
               <input class="form-control mb-2" name="image_url" id="image-url-input"
                      value="{{ draft.image_url or '' }}" placeholder="https://…" />
               <label class="form-label small text-muted mb-1">{{ t("label.or_upload_image") }}</label>
-              <form method="post" action="/items/{{ draft.id }}/upload-image"
-                    enctype="multipart/form-data" class="d-flex gap-2">
-                <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
+              <div class="d-flex gap-2">
                 <input type="file" name="file" accept="image/*" class="form-control form-control-sm" />
-                <button type="submit" class="btn btn-sm btn-secondary text-nowrap">{{ t("action.upload") }}</button>
-              </form>
+                <button type="submit"
+                        formaction="/items/{{ draft.id }}/upload-image"
+                        formmethod="post"
+                        formenctype="multipart/form-data"
+                        class="btn btn-sm btn-secondary text-nowrap">{{ t("action.upload") }}</button>
+              </div>
             </div>
           </div>
         </div>
@@ -441,8 +443,15 @@
   {% endif %}
 
   <div class="d-flex gap-2 mt-4 align-items-center flex-wrap">
-    <button class="btn btn-primary" type="submit">{% if mode == "edit" %}{{ t("common.save_changes") }}{% else %}{{ t("common.create_item") }}{% endif %}</button>
+    <button class="btn btn-primary" id="save-btn" type="submit"
+      {% if mode == "edit" %}disabled{% endif %}>
+      {% if mode == "edit" %}{{ t("common.save_changes") }}{% else %}{{ t("common.create_item") }}{% endif %}
+    </button>
+    {% if mode == "edit" %}
+    <a class="btn btn-outline-secondary" href="{{ back_url or '/' }}">{{ t("common.cancel") }}</a>
+    {% else %}
     <a class="btn btn-outline-secondary" href="/">{{ t("common.cancel") }}</a>
+    {% endif %}
     {% if mode != "edit" %}
     <div class="form-check ms-3 mb-0">
       <input class="form-check-input" type="checkbox" name="continue_adding" id="continue-adding-check" value="1">
@@ -605,6 +614,28 @@
           localStorage.setItem("lastLocation", hiddenLocs[0].value);
         }
       });
+    }
+
+    // ── Dirty-check: enable Save only when form data changes (EDIT mode) ──
+    const saveBtn = document.getElementById("save-btn");
+    const editForm = document.querySelector('form[action$="/update"]');
+    if (saveBtn && editForm) {
+      function getFormSnapshot() {
+        const parts = [];
+        editForm.querySelectorAll(
+          'input:not([type=hidden]):not([type=file]), select, textarea'
+        ).forEach(el => {
+          const v = (el.type === "checkbox" || el.type === "radio") ? el.checked : el.value;
+          parts.push(el.name + "=" + v);
+        });
+        return parts.join("|");
+      }
+      const originalSnapshot = getFormSnapshot();
+      function checkDirty() {
+        saveBtn.disabled = (getFormSnapshot() === originalSnapshot);
+      }
+      editForm.addEventListener("input", checkDirty);
+      editForm.addEventListener("change", checkDirty);
     }
 
     // ── Location plan modal for new locations (#53) ──────────────────────

--- a/app/version.py
+++ b/app/version.py
@@ -1,4 +1,4 @@
 """Application version constants. Update APP_VERSION on every release."""
 
-APP_VERSION = "1.1.2"
+APP_VERSION = "1.1.3"
 BUILD_DATE = "2026-03-17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockmgr"
-version = "1.1.2"
+version = "1.1.3"
 description = "SHTF stock inventory management web application"
 requires-python = ">=3.12"
 


### PR DESCRIPTION
## Root cause

A nested `<form>` (image upload section) was embedded inside the main item edit form. HTML does not allow nested forms; the browser implicitly closes the outer form when it encounters the inner `</form>`, so the Save button at the bottom ended up **outside any form**. Clicking it did nothing.

Only triggered in edit mode (image upload section is edit-only).

## Changes

- Replace inner `<form>` with `<div>`; add `formaction`/`formmethod`/`formenctype` on the Upload button so it submits to the upload endpoint
- Save button: `disabled` by default in edit mode; dirty-check JS enables it when any field changes
- Cancel button in edit mode now links to the product detail page (not home)
- Pass `back_url` from the edit route handler to the template

## Version
`1.1.2` → `1.1.3`  

Closes #93