### PR TITLE
fix: wrap sortable th headers in button for reliable sort clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to stockmgr are documented here. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.2.1] - 2026-03-17
+
+### Fixed
+- **Table column sorting non-functional (#95)**: sort click handlers were registered on `<th>` elements but produced no response in many browsers due to event-capture interference and lack of visible affordance. Fixed by replacing each sortable header's text with an explicit `<button class="sort-btn btn btn-link">` element — guarantees a reliable, browser-native click target.
+- **Sort header hover feedback**: column headers now highlight with a light primary tint on hover, giving users a clear visual cue that headers are interactive.
+
 ## [1.2.0] - 2026-03-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stockmgr
 
-![Version](https://img.shields.io/badge/version-1.2.0-blue)
+![Version](https://img.shields.io/badge/version-1.2.1-blue)
 
 Web MVP to manage SHTF stock inventorywith OAuth-capable authentication, barcode-assisted item entry, CSV/XLSX import, renewal-date calendar sync, and configurable product-information providers.
 

--- a/app/static/table-enhance.js
+++ b/app/static/table-enhance.js
@@ -4,6 +4,27 @@
     return;
   }
 
+  // Inject hover/cursor styles for sort buttons once per page
+  if (!document.getElementById("table-enhance-style")) {
+    const style = document.createElement("style");
+    style.id = "table-enhance-style";
+    style.textContent = [
+      "table[data-enhanced-table] .sort-btn{",
+        "text-decoration:none;vertical-align:baseline;",
+        "padding:0;border:none;background:none;",
+      "}",
+      "table[data-enhanced-table] .sort-btn:hover,",
+      "table[data-enhanced-table] .sort-btn:focus{",
+        "text-decoration:underline;outline:none;",
+      "}",
+      "table[data-enhanced-table] th{transition:background-color .1s;}",
+      "table[data-enhanced-table] th:has(.sort-btn):hover{",
+        "background-color:rgba(var(--bs-primary-rgb),.08);cursor:pointer;",
+      "}",
+    ].join("");
+    document.head.appendChild(style);
+  }
+
   const parseSortableValue = (text) => {
     const trimmed = text.trim();
     if (!trimmed) {
@@ -145,6 +166,23 @@
       return filtered;
     };
 
+    const updateSortIndicators = () => {
+      Array.from(headerRow.cells).forEach((th, index) => {
+        if (!sortable[index]) return;
+        const s = th.querySelector(".sort-icon");
+        if (!s) return;
+        if (state.sortIndex === index) {
+          s.textContent = state.sortDir === 1 ? " ↑" : " ↓";
+          s.classList.remove("text-muted");
+          s.classList.add("text-primary");
+        } else {
+          s.textContent = " ⇅";
+          s.classList.remove("text-primary");
+          s.classList.add("text-muted");
+        }
+      });
+    };
+
     const render = () => {
       const filtered = applyFiltersAndSort();
       const totalPages = Math.max(1, Math.ceil(filtered.length / state.pageSize));
@@ -162,12 +200,23 @@
       updateSortIndicators();
     };
 
+    // Replace each sortable header's text with a <button> for reliable clicking + link appearance
     Array.from(headerRow.cells).forEach((th, index) => {
       if (!sortable[index]) {
         return;
       }
-      th.style.cursor = "pointer";
-      th.addEventListener("click", () => {
+      const label = th.textContent.trim();
+      th.textContent = "";
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "sort-btn btn btn-link fw-semibold text-nowrap";
+      btn.textContent = label;
+      const icon = document.createElement("span");
+      icon.className = "sort-icon ms-1 text-muted";
+      icon.textContent = " ⇅";
+      btn.appendChild(icon);
+      th.appendChild(btn);
+      btn.addEventListener("click", () => {
         if (state.sortIndex === index) {
           state.sortDir = state.sortDir * -1;
         } else {
@@ -177,28 +226,6 @@
         render();
       });
     });
-
-    const updateSortIndicators = () => {
-      Array.from(headerRow.cells).forEach((th, index) => {
-        const icon = th.querySelector(".sort-icon");
-        if (!sortable[index]) return;
-        if (!icon) {
-          const span = document.createElement("span");
-          span.className = "sort-icon ms-1 text-muted";
-          th.appendChild(span);
-        }
-        const s = th.querySelector(".sort-icon");
-        if (state.sortIndex === index) {
-          s.textContent = state.sortDir === 1 ? " ↑" : " ↓";
-          s.classList.remove("text-muted");
-          s.classList.add("text-primary");
-        } else {
-          s.textContent = " ⇅";
-          s.classList.remove("text-primary");
-          s.classList.add("text-muted");
-        }
-      });
-    };
 
     searchInput.addEventListener("input", () => {
       state.globalFilter = searchInput.value;
@@ -220,7 +247,6 @@
     });
 
     render();
-    updateSortIndicators();
   });
 })();
 

--- a/app/version.py
+++ b/app/version.py
@@ -1,4 +1,4 @@
 """Application version constants. Update APP_VERSION on every release."""
 
-APP_VERSION = "1.2.0"
+APP_VERSION = "1.2.1"
 BUILD_DATE = "2026-03-17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockmgr"
-version = "1.2.0"
+version = "1.2.1"
 description = "SHTF stock inventory management web application"
 requires-python = ">=3.12"
 


### PR DESCRIPTION
Closes #95 (re-fix)

**Root cause**: Click handlers on bare `<th>` elements are unreliable across browsers — events on child nodes (icon span, text) may not bubble. 

**Fix**:
- Each sortable header text replaced with `<button class='sort-btn btn btn-link'>` — native button guarantees click events fire
- Sort icon lives inside the button
- CSS injected once: sortable `<th>` highlights (primary tint + pointer cursor) on hover
- Removed redundant `updateSortIndicators()` call after `render()`  

**Version**: v1.2.1

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>