### PR TITLE
fix: cache-bust static assets + delegated sort handler (v1.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to stockmgr are documented here. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.2.2] - 2026-03-17
+
+### Fixed
+- **Table column sorting still non-functional (#95)**: root-cause diagnosis revealed two issues: (1) browser was serving a stale cached `table-enhance.js` because the URL lacked a cache-busting parameter; (2) the dynamic `<style>` injection at script start was throwing before any tables were enhanced. Fixes:
+  - Sort styles moved to `site.css` (always loaded, no runtime injection)
+  - `site.css`, `table-enhance.js`, and `pwa-register.js` URLs now include `?v={{ app_version_semantic }}` for automatic cache-busting on every release
+  - Controls and pagination now inserted outside `.table-responsive` wrapper (avoids clipping by overflow container)
+  - Sort click handling switched to a single delegated listener on `<thead>` using `data-sort-col` stamps — more robust than per-button handlers
+  - Each table's forEach wrapped in `try/catch` so one failing table can't prevent others from being enhanced
+
 ## [1.2.1] - 2026-03-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stockmgr
 
-![Version](https://img.shields.io/badge/version-1.2.1-blue)
+![Version](https://img.shields.io/badge/version-1.2.2-blue)
 
 Web MVP to manage SHTF stock inventorywith OAuth-capable authentication, barcode-assisted item entry, CSV/XLSX import, renewal-date calendar sync, and configurable product-information providers.
 

--- a/app/static/site.css
+++ b/app/static/site.css
@@ -37,6 +37,36 @@ table th {
   min-width: 100px;
 }
 
+/* Sortable column header buttons */
+table[data-enhanced-table] .sort-btn {
+  padding: 0;
+  border: none;
+  background: none;
+  font-weight: 600;
+  font-size: inherit;
+  color: var(--bs-link-color, #0d6efd);
+  cursor: pointer;
+  text-decoration: none;
+  vertical-align: baseline;
+  white-space: nowrap;
+}
+table[data-enhanced-table] .sort-btn:hover,
+table[data-enhanced-table] .sort-btn:focus {
+  text-decoration: underline;
+  color: var(--bs-link-hover-color, #0a58ca);
+  outline: none;
+}
+table[data-enhanced-table] th:has(.sort-btn) {
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+table[data-enhanced-table] th:has(.sort-btn):hover {
+  background-color: rgba(13, 110, 253, 0.08);
+}
+table[data-enhanced-table] th.sort-active {
+  background-color: rgba(13, 110, 253, 0.05);
+}
+
 @media (max-width: 991.98px) {
   .navbar .btn-group-sm > .btn,
   .navbar .btn-sm {

--- a/app/static/table-enhance.js
+++ b/app/static/table-enhance.js
@@ -1,28 +1,9 @@
 (function () {
+  "use strict";
+
   const tables = document.querySelectorAll("table[data-enhanced-table]");
   if (!tables.length) {
     return;
-  }
-
-  // Inject hover/cursor styles for sort buttons once per page
-  if (!document.getElementById("table-enhance-style")) {
-    const style = document.createElement("style");
-    style.id = "table-enhance-style";
-    style.textContent = [
-      "table[data-enhanced-table] .sort-btn{",
-        "text-decoration:none;vertical-align:baseline;",
-        "padding:0;border:none;background:none;",
-      "}",
-      "table[data-enhanced-table] .sort-btn:hover,",
-      "table[data-enhanced-table] .sort-btn:focus{",
-        "text-decoration:underline;outline:none;",
-      "}",
-      "table[data-enhanced-table] th{transition:background-color .1s;}",
-      "table[data-enhanced-table] th:has(.sort-btn):hover{",
-        "background-color:rgba(var(--bs-primary-rgb),.08);cursor:pointer;",
-      "}",
-    ].join("");
-    document.head.appendChild(style);
   }
 
   const parseSortableValue = (text) => {
@@ -42,181 +23,115 @@
     return trimmed.toLowerCase();
   };
 
-  const createCellFilterInput = () => {
-    const input = document.createElement("input");
-    input.type = "text";
-    input.className = "form-control form-control-sm";
-    return input;
-  };
-
   tables.forEach((table) => {
-    const tbody = table.tBodies[0];
-    const thead = table.tHead;
-    if (!tbody || !thead || !thead.rows.length) {
-      return;
-    }
-
-    const headerRow = thead.rows[0];
-    const originalRows = Array.from(tbody.rows);
-    const columnCount = headerRow.cells.length;
-    const sortable = Array.from(headerRow.cells).map(
-      (th) => th.dataset.sortable !== "false"
-    );
-    const filterable = Array.from(headerRow.cells).map(
-      (th) => th.dataset.filterable !== "false"
-    );
-    const state = {
-      globalFilter: "",
-      columnFilters: new Array(columnCount).fill(""),
-      sortIndex: null,
-      sortDir: 1,
-      page: 1,
-      pageSize: 10,
-    };
-
-    const controls = document.createElement("div");
-    controls.className = "table-enhance-controls d-flex flex-wrap gap-2 mb-2";
-    const searchInput = document.createElement("input");
-    searchInput.type = "text";
-    searchInput.className = "form-control form-control-sm";
-    searchInput.style.maxWidth = "240px";
-    searchInput.placeholder = "Search";
-    const pageSizeSelect = document.createElement("select");
-    pageSizeSelect.className = "form-select form-select-sm";
-    pageSizeSelect.style.maxWidth = "100px";
-    [10, 25, 50].forEach((size) => {
-      const option = document.createElement("option");
-      option.value = String(size);
-      option.textContent = String(size);
-      pageSizeSelect.appendChild(option);
-    });
-    controls.appendChild(searchInput);
-    controls.appendChild(pageSizeSelect);
-    table.parentElement.insertBefore(controls, table);
-
-    const filterRow = document.createElement("tr");
-    filterRow.className = "table-filter-row";
-    for (let i = 0; i < columnCount; i += 1) {
-      const th = document.createElement("th");
-      if (filterable[i]) {
-        const input = createCellFilterInput();
-        input.addEventListener("input", () => {
-          state.columnFilters[i] = input.value.trim().toLowerCase();
-          state.page = 1;
-          render();
-        });
-        th.appendChild(input);
-      }
-      filterRow.appendChild(th);
-    }
-    thead.appendChild(filterRow);
-
-    const pagination = document.createElement("div");
-    pagination.className = "table-pagination d-flex align-items-center gap-2 mt-2";
-    const prevButton = document.createElement("button");
-    prevButton.type = "button";
-    prevButton.className = "btn btn-sm btn-outline-secondary";
-    prevButton.textContent = "Prev";
-    const nextButton = document.createElement("button");
-    nextButton.type = "button";
-    nextButton.className = "btn btn-sm btn-outline-secondary";
-    nextButton.textContent = "Next";
-    const pageInfo = document.createElement("span");
-    pageInfo.className = "small text-muted";
-    pagination.appendChild(prevButton);
-    pagination.appendChild(nextButton);
-    pagination.appendChild(pageInfo);
-    table.parentElement.appendChild(pagination);
-
-    const applyFiltersAndSort = () => {
-      const globalQuery = state.globalFilter.trim().toLowerCase();
-      let filtered = originalRows.filter((row) => {
-        const cells = Array.from(row.cells).map((cell) =>
-          (cell.textContent || "").trim().toLowerCase()
-        );
-        if (globalQuery && !cells.some((value) => value.includes(globalQuery))) {
-          return false;
-        }
-        for (let i = 0; i < state.columnFilters.length; i += 1) {
-          if (!state.columnFilters[i]) {
-            continue;
-          }
-          if (!cells[i].includes(state.columnFilters[i])) {
-            return false;
-          }
-        }
-        return true;
-      });
-
-      if (state.sortIndex !== null) {
-        const idx = state.sortIndex;
-        const direction = state.sortDir;
-        filtered = filtered.slice().sort((leftRow, rightRow) => {
-          const left = parseSortableValue(leftRow.cells[idx]?.textContent || "");
-          const right = parseSortableValue(rightRow.cells[idx]?.textContent || "");
-          if (left < right) {
-            return -1 * direction;
-          }
-          if (left > right) {
-            return 1 * direction;
-          }
-          return 0;
-        });
-      }
-      return filtered;
-    };
-
-    const updateSortIndicators = () => {
-      Array.from(headerRow.cells).forEach((th, index) => {
-        if (!sortable[index]) return;
-        const s = th.querySelector(".sort-icon");
-        if (!s) return;
-        if (state.sortIndex === index) {
-          s.textContent = state.sortDir === 1 ? " ↑" : " ↓";
-          s.classList.remove("text-muted");
-          s.classList.add("text-primary");
-        } else {
-          s.textContent = " ⇅";
-          s.classList.remove("text-primary");
-          s.classList.add("text-muted");
-        }
-      });
-    };
-
-    const render = () => {
-      const filtered = applyFiltersAndSort();
-      const totalPages = Math.max(1, Math.ceil(filtered.length / state.pageSize));
-      if (state.page > totalPages) {
-        state.page = totalPages;
-      }
-      const start = (state.page - 1) * state.pageSize;
-      const end = start + state.pageSize;
-      const pageRows = filtered.slice(start, end);
-      tbody.replaceChildren(...pageRows);
-
-      prevButton.disabled = state.page <= 1;
-      nextButton.disabled = state.page >= totalPages;
-      pageInfo.textContent = `Page ${state.page} / ${totalPages}`;
-      updateSortIndicators();
-    };
-
-    // Replace each sortable header's text with a <button> for reliable clicking + link appearance
-    Array.from(headerRow.cells).forEach((th, index) => {
-      if (!sortable[index]) {
+    try {
+      const tbody = table.tBodies[0];
+      const thead = table.tHead;
+      if (!tbody || !thead || !thead.rows.length) {
         return;
       }
-      const label = th.textContent.trim();
-      th.textContent = "";
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "sort-btn btn btn-link fw-semibold text-nowrap";
-      btn.textContent = label;
-      const icon = document.createElement("span");
-      icon.className = "sort-icon ms-1 text-muted";
-      icon.textContent = " ⇅";
-      btn.appendChild(icon);
-      th.appendChild(btn);
-      btn.addEventListener("click", () => {
+
+      const headerRow = thead.rows[0];
+      const originalRows = Array.from(tbody.rows);
+      const columnCount = headerRow.cells.length;
+      const sortable = Array.from(headerRow.cells).map(
+        (th) => th.dataset.sortable !== "false"
+      );
+      const filterable = Array.from(headerRow.cells).map(
+        (th) => th.dataset.filterable !== "false"
+      );
+      const state = {
+        globalFilter: "",
+        columnFilters: new Array(columnCount).fill(""),
+        sortIndex: null,
+        sortDir: 1,
+        page: 1,
+        pageSize: 10,
+      };
+
+      // Insert controls outside .table-responsive if present, otherwise before table
+      const insertTarget = table.closest(".table-responsive") || table;
+      const insertParent = insertTarget.parentElement;
+
+      const controls = document.createElement("div");
+      controls.className = "table-enhance-controls d-flex flex-wrap gap-2 mb-2";
+      const searchInput = document.createElement("input");
+      searchInput.type = "text";
+      searchInput.className = "form-control form-control-sm";
+      searchInput.style.maxWidth = "240px";
+      searchInput.placeholder = "Search";
+      const pageSizeSelect = document.createElement("select");
+      pageSizeSelect.className = "form-select form-select-sm";
+      pageSizeSelect.style.maxWidth = "100px";
+      [10, 25, 50].forEach((size) => {
+        const option = document.createElement("option");
+        option.value = String(size);
+        option.textContent = String(size);
+        pageSizeSelect.appendChild(option);
+      });
+      controls.appendChild(searchInput);
+      controls.appendChild(pageSizeSelect);
+      insertParent.insertBefore(controls, insertTarget);
+
+      const filterRow = document.createElement("tr");
+      filterRow.className = "table-filter-row";
+      for (let i = 0; i < columnCount; i += 1) {
+        const th = document.createElement("th");
+        if (filterable[i]) {
+          const input = document.createElement("input");
+          input.type = "text";
+          input.className = "form-control form-control-sm";
+          input.addEventListener("input", () => {
+            state.columnFilters[i] = input.value.trim().toLowerCase();
+            state.page = 1;
+            render();
+          });
+          th.appendChild(input);
+        }
+        filterRow.appendChild(th);
+      }
+      thead.appendChild(filterRow);
+
+      const pagination = document.createElement("div");
+      pagination.className = "table-pagination d-flex align-items-center gap-2 mt-2";
+      const prevButton = document.createElement("button");
+      prevButton.type = "button";
+      prevButton.className = "btn btn-sm btn-outline-secondary";
+      prevButton.textContent = "Prev";
+      const nextButton = document.createElement("button");
+      nextButton.type = "button";
+      nextButton.className = "btn btn-sm btn-outline-secondary";
+      nextButton.textContent = "Next";
+      const pageInfo = document.createElement("span");
+      pageInfo.className = "small text-muted";
+      pagination.appendChild(prevButton);
+      pagination.appendChild(nextButton);
+      pagination.appendChild(pageInfo);
+      insertParent.insertBefore(pagination, insertTarget.nextSibling);
+
+      // Stamp each sortable header with its column index for delegated click handling
+      Array.from(headerRow.cells).forEach((th, index) => {
+        if (!sortable[index]) return;
+        th.dataset.sortCol = String(index);
+        const label = th.textContent.trim();
+        th.textContent = "";
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "sort-btn";
+        btn.textContent = label;
+        const icon = document.createElement("span");
+        icon.className = "sort-icon";
+        icon.setAttribute("aria-hidden", "true");
+        icon.textContent = " \u21C5";
+        btn.appendChild(icon);
+        th.appendChild(btn);
+      });
+
+      // Single delegated listener on <thead> - catches clicks anywhere inside a sortable header
+      thead.addEventListener("click", (e) => {
+        const th = e.target.closest("th[data-sort-col]");
+        if (!th) return;
+        const index = parseInt(th.dataset.sortCol, 10);
         if (state.sortIndex === index) {
           state.sortDir = state.sortDir * -1;
         } else {
@@ -225,28 +140,88 @@
         }
         render();
       });
-    });
 
-    searchInput.addEventListener("input", () => {
-      state.globalFilter = searchInput.value;
-      state.page = 1;
-      render();
-    });
-    pageSizeSelect.addEventListener("change", () => {
-      state.pageSize = Number(pageSizeSelect.value);
-      state.page = 1;
-      render();
-    });
-    prevButton.addEventListener("click", () => {
-      state.page = Math.max(1, state.page - 1);
-      render();
-    });
-    nextButton.addEventListener("click", () => {
-      state.page += 1;
-      render();
-    });
+      const applyFiltersAndSort = () => {
+        const globalQuery = state.globalFilter.trim().toLowerCase();
+        let filtered = originalRows.filter((row) => {
+          const cells = Array.from(row.cells).map((cell) =>
+            (cell.textContent || "").trim().toLowerCase()
+          );
+          if (globalQuery && !cells.some((v) => v.includes(globalQuery))) {
+            return false;
+          }
+          for (let i = 0; i < state.columnFilters.length; i += 1) {
+            if (state.columnFilters[i] && !cells[i].includes(state.columnFilters[i])) {
+              return false;
+            }
+          }
+          return true;
+        });
 
-    render();
+        if (state.sortIndex !== null) {
+          const idx = state.sortIndex;
+          const dir = state.sortDir;
+          filtered = filtered.slice().sort((a, b) => {
+            const left = parseSortableValue(a.cells[idx]?.textContent || "");
+            const right = parseSortableValue(b.cells[idx]?.textContent || "");
+            if (left < right) return -1 * dir;
+            if (left > right) return 1 * dir;
+            return 0;
+          });
+        }
+        return filtered;
+      };
+
+      const updateSortIndicators = () => {
+        Array.from(headerRow.cells).forEach((th, index) => {
+          if (!sortable[index]) return;
+          const icon = th.querySelector(".sort-icon");
+          if (!icon) return;
+          if (state.sortIndex === index) {
+            icon.textContent = state.sortDir === 1 ? " \u2191" : " \u2193";
+            th.classList.add("sort-active");
+          } else {
+            icon.textContent = " \u21C5";
+            th.classList.remove("sort-active");
+          }
+        });
+      };
+
+      const render = () => {
+        const filtered = applyFiltersAndSort();
+        const totalPages = Math.max(1, Math.ceil(filtered.length / state.pageSize));
+        if (state.page > totalPages) state.page = totalPages;
+        const start = (state.page - 1) * state.pageSize;
+        tbody.replaceChildren(...filtered.slice(start, start + state.pageSize));
+        prevButton.disabled = state.page <= 1;
+        nextButton.disabled = state.page >= totalPages;
+        pageInfo.textContent = "Page " + state.page + " / " + totalPages;
+        updateSortIndicators();
+      };
+
+      searchInput.addEventListener("input", () => {
+        state.globalFilter = searchInput.value;
+        state.page = 1;
+        render();
+      });
+      pageSizeSelect.addEventListener("change", () => {
+        state.pageSize = Number(pageSizeSelect.value);
+        state.page = 1;
+        render();
+      });
+      prevButton.addEventListener("click", () => {
+        state.page = Math.max(1, state.page - 1);
+        render();
+      });
+      nextButton.addEventListener("click", () => {
+        state.page += 1;
+        render();
+      });
+
+      render();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error("[table-enhance] failed to enhance table:", err);
+    }
   });
 })();
-

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,7 +15,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', path='icons/icon-180.png') }}" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
-    <link href="{{ url_for('static', path='site.css') }}" rel="stylesheet" />
+    <link href="{{ url_for('static', path='site.css') }}?v={{ app_version_semantic }}" rel="stylesheet" />
   </head>
   <body>
     <nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom">
@@ -82,8 +82,8 @@
       {% block content %}{% endblock %}
     </main>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="{{ url_for('static', path='table-enhance.js') }}"></script>
-    <script src="{{ url_for('static', path='pwa-register.js') }}"></script>
+    <script src="{{ url_for('static', path='table-enhance.js') }}?v={{ app_version_semantic }}"></script>
+    <script src="{{ url_for('static', path='pwa-register.js') }}?v={{ app_version_semantic }}"></script>
     <script>
     (function() {
       const MSG = {{ t("common.unsaved_changes") | tojson }};

--- a/app/version.py
+++ b/app/version.py
@@ -1,4 +1,4 @@
 """Application version constants. Update APP_VERSION on every release."""
 
-APP_VERSION = "1.2.1"
+APP_VERSION = "1.2.2"
 BUILD_DATE = "2026-03-17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockmgr"
-version = "1.2.1"
+version = "1.2.2"
 description = "SHTF stock inventory management web application"
 requires-python = ">=3.12"
 


### PR DESCRIPTION
Closes #95 (definitive fix)

Two root causes identified:
1. Browser cached stale table-enhance.js (no cache-busting URL) - fixed with ?v=APP_VERSION
2. Dynamic style injection failed silently before table enhancement ran - moved to site.css

Also: delegated click on thead (more robust), controls outside .table-responsive, try/catch per table

Bumped to v1.2.2

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>