### PR TITLE
fix: replace url_for static with root-relative paths to fix mixed content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to stockmgr are documented here. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.2.3] - 2026-03-17
+
+### Fixed
+- **Mixed content blocking all static assets (#103, #95)**: `url_for('static', path=...)` in Jinja2 was generating absolute `http://` URLs. Because the app runs behind Azure's HTTPS reverse proxy without `ProxyHeadersMiddleware`, FastAPI saw every request as HTTP and built HTTP static-file URLs. Browsers block `http://` scripts and stylesheets loaded from an `https://` page as mixed content — silently, in the background. This prevented `table-enhance.js` (and `site.css`) from ever loading, which is why column sorting never worked regardless of the JavaScript fixes applied in v1.2.1 and v1.2.2.
+  - **Fix**: replaced all `url_for('static', path='...')` calls in `base.html` and `device_check.html` with root-relative `/static/...` paths. A root-relative path inherits the page scheme, so it is always `https://` in production and works correctly in local HTTP development too.
+
 ## [1.2.2] - 2026-03-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stockmgr
 
-![Version](https://img.shields.io/badge/version-1.2.2-blue)
+![Version](https://img.shields.io/badge/version-1.2.3-blue)
 
 Web MVP to manage SHTF stock inventorywith OAuth-capable authentication, barcode-assisted item entry, CSV/XLSX import, renewal-date calendar sync, and configurable product-information providers.
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,14 +8,14 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <title>stockmgr</title>
     <link rel="manifest" href="/manifest.webmanifest" />
-    <link rel="icon" type="image/x-icon" href="{{ url_for('static', path='icons/favicon.ico') }}" />
-    <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', path='icons/icon-32.png') }}" />
-    <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', path='icons/icon-16.png') }}" />
-    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', path='icons/icon.svg') }}" />
-    <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', path='icons/icon-180.png') }}" />
+    <link rel="icon" type="image/x-icon" href="/static/icons/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/static/icons/icon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/static/icons/icon-16.png" />
+    <link rel="icon" type="image/svg+xml" href="/static/icons/icon.svg" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/icon-180.png" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet" />
-    <link href="{{ url_for('static', path='site.css') }}?v={{ app_version_semantic }}" rel="stylesheet" />
+    <link href="/static/site.css?v={{ app_version_semantic }}" rel="stylesheet" />
   </head>
   <body>
     <nav class="navbar navbar-expand-lg bg-body-tertiary border-bottom">
@@ -82,8 +82,8 @@
       {% block content %}{% endblock %}
     </main>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="{{ url_for('static', path='table-enhance.js') }}?v={{ app_version_semantic }}"></script>
-    <script src="{{ url_for('static', path='pwa-register.js') }}?v={{ app_version_semantic }}"></script>
+    <script src="/static/table-enhance.js?v={{ app_version_semantic }}"></script>
+    <script src="/static/pwa-register.js?v={{ app_version_semantic }}"></script>
     <script>
     (function() {
       const MSG = {{ t("common.unsaved_changes") | tojson }};

--- a/app/templates/device_check.html
+++ b/app/templates/device_check.html
@@ -56,5 +56,5 @@
   data-not-supported="{{ t('device.not_supported') }}"
 ></div>
 
-<script src="{{ url_for('static', path='device-check.js') }}"></script>
+<script src="/static/device-check.js"></script>
 {% endblock %}

--- a/app/version.py
+++ b/app/version.py
@@ -1,4 +1,4 @@
 """Application version constants. Update APP_VERSION on every release."""
 
-APP_VERSION = "1.2.2"
+APP_VERSION = "1.2.3"
 BUILD_DATE = "2026-03-17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockmgr"
-version = "1.2.2"
+version = "1.2.3"
 description = "SHTF stock inventory management web application"
 requires-python = ">=3.12"
 


### PR DESCRIPTION
Closes #103. Fixes root cause of #95.

url_for('static',...) generated http:// URLs (app behind Azure HTTPS proxy without ProxyHeadersMiddleware). Browsers silently blocked table-enhance.js and site.css as mixed content -- table sorting NEVER loaded.

Fix: all /static/... references use root-relative paths (inherit page scheme). Bumped to v1.2.3.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>