### PR TITLE
feat: BenchmarkItem model and curated seed data (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to stockmgr are documented here. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.3.6] - 2026-04-21
+### Added
+- `BenchmarkItem` SQLModel table with curated prepper seed data (35 items across food, medicine, hygiene, energy, seeds, tools, communication) (#126)
+- `app/benchmark_seed.py`: idempotent `seed_benchmark_if_empty()` called at startup via lifespan (#126)
+- i18n keys: `benchmark.title`, `benchmark.category`, `benchmark.qty_per_day`, `benchmark.scales`, `benchmark.notes`, `benchmark.name`, `benchmark.uom` (EN + PT) (#126)
+
 ## [1.3.5] - 2026-04-21
 ### Added
 - Item form: `item_category` radio (Food/Non-food) and `non_food_category` select, shown prominently after barcode section (#125)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stockmgr
 
-![version](https://img.shields.io/badge/version-1.3.5-blue)
+![version](https://img.shields.io/badge/version-1.3.6-blue)
 
 
 Web MVP to manage SHTF stock inventorywith OAuth-capable authentication, barcode-assisted item entry, CSV/XLSX import, renewal-date calendar sync, and configurable product-information providers.

--- a/app/benchmark_seed.py
+++ b/app/benchmark_seed.py
@@ -1,0 +1,234 @@
+"""Idempotent seeder for BenchmarkItem curated prepper data."""
+from __future__ import annotations
+
+from app.models import BenchmarkItem
+from sqlmodel import Session, select
+
+
+def seed_benchmark_if_empty(session: Session) -> int:
+    """Insert benchmark items if the table is empty. Returns count inserted."""
+    existing = session.exec(select(BenchmarkItem)).first()
+    if existing:
+        return 0
+    items = _get_seed_data()
+    for item in items:
+        session.add(item)
+    session.commit()
+    return len(items)
+
+
+def _get_seed_data() -> list[BenchmarkItem]:  # noqa: PLR0915
+    return [
+        # ── Water ──────────────────────────────────────────────────────────────
+        BenchmarkItem(
+            name="Drinking water", name_pt="Água potável",
+            item_category="food", qty_per_day=2.0, uom="L",
+            scales_with_participants=True,
+            notes="Minimum 2L; 4L recommended including cooking",
+            notes_pt="Mínimo 2L; 4L recomendado incluindo cozinha",
+            sort_order=0,
+        ),
+        BenchmarkItem(
+            name="Water purification tablets", name_pt="Comprimidos purificação água",
+            item_category="food", qty_per_day=2.0, uom="unit",
+            scales_with_participants=True, sort_order=1,
+        ),
+        # ── Food ───────────────────────────────────────────────────────────────
+        BenchmarkItem(
+            name="Rice", name_pt="Arroz",
+            item_category="food", qty_per_day=0.2, uom="kg",
+            scales_with_participants=True, sort_order=2,
+        ),
+        BenchmarkItem(
+            name="Legumes (beans/lentils)", name_pt="Leguminosas (feijão/lentilhas)",
+            item_category="food", qty_per_day=0.1, uom="kg",
+            scales_with_participants=True, sort_order=3,
+        ),
+        BenchmarkItem(
+            name="Cooking oil", name_pt="Óleo de cozinha",
+            item_category="food", qty_per_day=0.04, uom="L",
+            scales_with_participants=True, sort_order=4,
+        ),
+        BenchmarkItem(
+            name="Salt", name_pt="Sal",
+            item_category="food", qty_per_day=0.01, uom="kg",
+            scales_with_participants=True, sort_order=5,
+        ),
+        BenchmarkItem(
+            name="Sugar", name_pt="Açúcar",
+            item_category="food", qty_per_day=0.05, uom="kg",
+            scales_with_participants=True, sort_order=6,
+        ),
+        BenchmarkItem(
+            name="Flour", name_pt="Farinha",
+            item_category="food", qty_per_day=0.15, uom="kg",
+            scales_with_participants=True, sort_order=7,
+        ),
+        BenchmarkItem(
+            name="Canned vegetables", name_pt="Vegetais em lata",
+            item_category="food", qty_per_day=1.0, uom="unit",
+            scales_with_participants=True, sort_order=8,
+        ),
+        BenchmarkItem(
+            name="Canned fish/meat", name_pt="Peixe/carne em lata",
+            item_category="food", qty_per_day=1.0, uom="unit",
+            scales_with_participants=True, sort_order=9,
+        ),
+        BenchmarkItem(
+            name="Dried fruit/nuts", name_pt="Frutos secos",
+            item_category="food", qty_per_day=0.05, uom="kg",
+            scales_with_participants=True, sort_order=10,
+        ),
+        BenchmarkItem(
+            name="Honey", name_pt="Mel",
+            item_category="food", qty_per_day=0.02, uom="kg",
+            scales_with_participants=True, sort_order=11,
+        ),
+        # ── Medicine ───────────────────────────────────────────────────────────
+        BenchmarkItem(
+            name="Paracetamol 500mg", name_pt="Paracetamol 500mg",
+            item_category="non_food", non_food_category="medicine",
+            qty_per_day=2.0, uom="dose",
+            scales_with_participants=True, sort_order=12,
+        ),
+        BenchmarkItem(
+            name="Ibuprofen 400mg", name_pt="Ibuprofeno 400mg",
+            item_category="non_food", non_food_category="medicine",
+            qty_per_day=2.0, uom="dose",
+            scales_with_participants=True, sort_order=13,
+        ),
+        BenchmarkItem(
+            name="Oral rehydration salts", name_pt="Sais de rehidratação oral",
+            item_category="non_food", non_food_category="medicine",
+            qty_per_day=1.0, uom="pack",
+            scales_with_participants=True, sort_order=14,
+        ),
+        BenchmarkItem(
+            name="Antiseptic solution", name_pt="Solução antisséptica",
+            item_category="non_food", non_food_category="medicine",
+            qty_per_day=0.01, uom="L",
+            scales_with_participants=False, sort_order=15,
+        ),
+        BenchmarkItem(
+            name="Bandages (sterile)", name_pt="Ligaduras (estéreis)",
+            item_category="non_food", non_food_category="medicine",
+            qty_per_day=0.1, uom="unit",
+            scales_with_participants=True, sort_order=16,
+        ),
+        # ── Hygiene ────────────────────────────────────────────────────────────
+        BenchmarkItem(
+            name="Toilet paper", name_pt="Papel higiénico",
+            item_category="non_food", non_food_category="hygiene",
+            qty_per_day=0.14, uom="roll",
+            scales_with_participants=True, sort_order=17,
+        ),
+        BenchmarkItem(
+            name="Soap (bar)", name_pt="Sabão (barra)",
+            item_category="non_food", non_food_category="hygiene",
+            qty_per_day=0.033, uom="unit",
+            scales_with_participants=True, sort_order=18,
+        ),
+        BenchmarkItem(
+            name="Toothpaste", name_pt="Pasta de dentes",
+            item_category="non_food", non_food_category="hygiene",
+            qty_per_day=0.007, uom="unit",
+            scales_with_participants=True, sort_order=19,
+        ),
+        BenchmarkItem(
+            name="Hand sanitiser", name_pt="Gel desinfetante",
+            item_category="non_food", non_food_category="hygiene",
+            qty_per_day=0.01, uom="L",
+            scales_with_participants=True, sort_order=20,
+        ),
+        # ── Energy ─────────────────────────────────────────────────────────────
+        BenchmarkItem(
+            name="Fuel (generator)", name_pt="Combustível (gerador)",
+            item_category="non_food", non_food_category="energy",
+            qty_per_day=0.3, uom="L",
+            scales_with_participants=False,
+            notes="Per kWh produced; household level",
+            notes_pt="Por kWh produzido; nível doméstico",
+            sort_order=21,
+        ),
+        BenchmarkItem(
+            name="Candles", name_pt="Velas",
+            item_category="non_food", non_food_category="energy",
+            qty_per_day=2.0, uom="unit",
+            scales_with_participants=False, sort_order=22,
+        ),
+        BenchmarkItem(
+            name="Batteries (AA)", name_pt="Pilhas AA",
+            item_category="non_food", non_food_category="energy",
+            qty_per_day=0.1, uom="unit",
+            scales_with_participants=False, sort_order=23,
+        ),
+        BenchmarkItem(
+            name="Firewood/charcoal", name_pt="Lenha/carvão",
+            item_category="non_food", non_food_category="energy",
+            qty_per_day=2.0, uom="kg",
+            scales_with_participants=False, sort_order=24,
+        ),
+        # ── Seeds ──────────────────────────────────────────────────────────────
+        BenchmarkItem(
+            name="Tomato seeds", name_pt="Sementes de tomate",
+            item_category="non_food", non_food_category="seeds",
+            qty_per_day=0.011, uom="pack",
+            scales_with_participants=False, sort_order=25,
+        ),
+        BenchmarkItem(
+            name="Potato seeds", name_pt="Batata-semente",
+            item_category="non_food", non_food_category="seeds",
+            qty_per_day=0.055, uom="kg",
+            scales_with_participants=False, sort_order=26,
+        ),
+        BenchmarkItem(
+            name="Bean seeds", name_pt="Sementes de feijão",
+            item_category="non_food", non_food_category="seeds",
+            qty_per_day=0.022, uom="kg",
+            scales_with_participants=False, sort_order=27,
+        ),
+        BenchmarkItem(
+            name="Root vegetable seeds", name_pt="Sementes de raízes",
+            item_category="non_food", non_food_category="seeds",
+            qty_per_day=0.011, uom="pack",
+            scales_with_participants=False, sort_order=28,
+        ),
+        # ── Tools ──────────────────────────────────────────────────────────────
+        BenchmarkItem(
+            name="Multi-tool", name_pt="Canivete/ferramenta",
+            item_category="non_food", non_food_category="tools",
+            qty_per_day=0.003, uom="unit",
+            scales_with_participants=False, sort_order=29,
+        ),
+        BenchmarkItem(
+            name="Axe/hatchet", name_pt="Machado/machadinha",
+            item_category="non_food", non_food_category="tools",
+            qty_per_day=0.003, uom="unit",
+            scales_with_participants=False, sort_order=30,
+        ),
+        BenchmarkItem(
+            name="Rope (paracord 50m)", name_pt="Corda (paracord 50m)",
+            item_category="non_food", non_food_category="tools",
+            qty_per_day=0.003, uom="unit",
+            scales_with_participants=False, sort_order=31,
+        ),
+        BenchmarkItem(
+            name="Flashlight", name_pt="Lanterna",
+            item_category="non_food", non_food_category="tools",
+            qty_per_day=0.003, uom="unit",
+            scales_with_participants=True, sort_order=32,
+        ),
+        # ── Communication ──────────────────────────────────────────────────────
+        BenchmarkItem(
+            name="Hand-crank radio", name_pt="Rádio de manivela",
+            item_category="non_food", non_food_category="communication",
+            qty_per_day=0.003, uom="unit",
+            scales_with_participants=False, sort_order=33,
+        ),
+        BenchmarkItem(
+            name="Walkie-talkies (pair)", name_pt="Walkie-talkies (par)",
+            item_category="non_food", non_food_category="communication",
+            qty_per_day=0.003, uom="unit",
+            scales_with_participants=False, sort_order=34,
+        ),
+    ]

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -338,6 +338,13 @@ TRANSLATIONS = {
         "uom.roll": "Rolls",
         "uom.m2": "Square metres (m2)",
         "uom.kWh": "Kilowatt-hours (kWh)",
+        "benchmark.title": "Recommended Stock List",
+        "benchmark.category": "Category",
+        "benchmark.qty_per_day": "Qty / Day",
+        "benchmark.scales": "Scales with participants",
+        "benchmark.notes": "Notes",
+        "benchmark.name": "Name",
+        "benchmark.uom": "Unit",
     },
     "pt": {
         "nav.add_item": "Adicionar Item",
@@ -680,6 +687,13 @@ TRANSLATIONS = {
         "uom.roll": "Rolos",
         "uom.m2": "Metros quadrados (m2)",
         "uom.kWh": "Quilowatt-hora (kWh)",
+        "benchmark.title": "Lista de Stock Recomendado",
+        "benchmark.category": "Categoria",
+        "benchmark.qty_per_day": "Qtd / Dia",
+        "benchmark.scales": "Escala com participantes",
+        "benchmark.notes": "Notas",
+        "benchmark.name": "Nome",
+        "benchmark.uom": "Unidade",
     },
 }
 

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,7 @@ from starlette.middleware.sessions import SessionMiddleware
 
 from app.backup_utils import create_backup, list_backups, restore_backup
 from app.config import get_settings
-from app.db import _sqlite_path_from_url, get_session, init_db
+from app.db import _sqlite_path_from_url, engine, get_session, init_db
 from app.food_wheel import FOOD_GROUP_BY_KEY, FOOD_GROUPS, food_group_chart_data, infer_food_group
 from app.i18n import SUPPORTED_LANGUAGES, translate
 from app.models import LocationPlan, StockItem, StockMovement, User
@@ -78,6 +78,11 @@ async def lifespan(_: FastAPI):
             db_file = (Path.cwd() / db_file).resolve()
         create_backup(db_file)
     init_db()
+    from app.benchmark_seed import seed_benchmark_if_empty  # noqa: PLC0415
+    with Session(engine) as session:
+        count = seed_benchmark_if_empty(session)
+        if count:
+            logger.info("Seeded %d benchmark items", count)
     yield
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -83,3 +83,20 @@ class StockMovement(SQLModel, table=True):
     delta: int = Field(nullable=False)
     note: str | None = Field(default=None)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), nullable=False)
+
+
+class BenchmarkItem(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(nullable=False)
+    name_pt: str = Field(nullable=False)
+    item_category: str = Field(nullable=False)        # "food" | "non_food"
+    non_food_category: str | None = Field(default=None)  # e.g. "medicine"
+    qty_per_day: float = Field(nullable=False)        # per person (or household if scales=False)
+    uom: str = Field(nullable=False)                  # from UOM_OPTIONS keys
+    scales_with_participants: bool = Field(default=True)
+    notes: str | None = Field(default=None)
+    notes_pt: str | None = Field(default=None)
+    sort_order: int = Field(default=0)
+    is_active: bool = Field(default=True)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/app/version.py
+++ b/app/version.py
@@ -1,5 +1,5 @@
 """Application version constants. Update APP_VERSION on every release."""
 
-APP_VERSION = "1.3.5"
+APP_VERSION = "1.3.6"
 BUILD_DATE = "2026-04-21"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockmgr"
-version = "1.3.5"
+version = "1.3.6"
 description = "SHTF stock inventory management web application"
 requires-python = ">=3.12"
 

--- a/tests/test_benchmark_seed.py
+++ b/tests/test_benchmark_seed.py
@@ -1,0 +1,77 @@
+"""Tests for BenchmarkItem model and seed data."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.benchmark_seed import seed_benchmark_if_empty
+from app.models import BenchmarkItem
+
+
+@pytest.fixture()
+def mem_engine():
+    """In-memory SQLite engine with all tables created fresh."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    SQLModel.metadata.drop_all(engine)
+
+
+def test_seed_inserts_items_on_empty_db(mem_engine):
+    with Session(mem_engine) as session:
+        count = seed_benchmark_if_empty(session)
+    assert count > 25, f"Expected >25 items seeded, got {count}"
+
+
+def test_seed_is_idempotent(mem_engine):
+    with Session(mem_engine) as session:
+        first = seed_benchmark_if_empty(session)
+        second = seed_benchmark_if_empty(session)
+    assert first > 0
+    assert second == 0
+    with Session(mem_engine) as session:
+        all_items = session.exec(select(BenchmarkItem)).all()
+    assert len(all_items) == first
+
+
+def test_benchmark_item_has_required_fields(mem_engine):
+    with Session(mem_engine) as session:
+        seed_benchmark_if_empty(session)
+        food_items = session.exec(
+            select(BenchmarkItem).where(BenchmarkItem.item_category == "food")
+        ).all()
+        non_food_items = session.exec(
+            select(BenchmarkItem).where(BenchmarkItem.item_category == "non_food")
+        ).all()
+    assert len(food_items) > 0, "Expected at least one food item"
+    assert len(non_food_items) > 0, "Expected at least one non_food item"
+    for item in food_items + non_food_items:
+        assert item.name, "Item must have a name"
+        assert item.name_pt, "Item must have a PT name"
+        assert item.uom, "Item must have a UOM"
+        assert item.qty_per_day >= 0, "qty_per_day must be non-negative"
+
+
+def test_scales_with_participants_flag(mem_engine):
+    with Session(mem_engine) as session:
+        seed_benchmark_if_empty(session)
+        scales_true = session.exec(
+            select(BenchmarkItem).where(BenchmarkItem.scales_with_participants == True)  # noqa: E712
+        ).all()
+        scales_false = session.exec(
+            select(BenchmarkItem).where(BenchmarkItem.scales_with_participants == False)  # noqa: E712
+        ).all()
+    assert len(scales_true) > 0, "Expected items with scales_with_participants=True (water, rice…)"
+    assert len(scales_false) > 0, "Expected items with scales_with_participants=False (fuel, candles…)"
+    scales_true_names = {i.name for i in scales_true}
+    scales_false_names = {i.name for i in scales_false}
+    assert "Drinking water" in scales_true_names
+    assert "Rice" in scales_true_names
+    assert "Fuel (generator)" in scales_false_names
+    assert "Candles" in scales_false_names


### PR DESCRIPTION
Implements #126

## Changes
- pp/models.py: BenchmarkItem SQLModel table (auto-created by SQLModel on startup)
- pp/benchmark_seed.py: idempotent seeder with 35 curated prepper items across food, medicine, hygiene, energy, seeds, tools, and communication categories
- pp/main.py: call seed_benchmark_if_empty in lifespan after init_db(); import ngine from pp.db
- pp/i18n.py: enchmark.* i18n keys (EN + PT)
- 	ests/test_benchmark_seed.py: 4 tests (insert on empty DB, idempotency, required fields, scales_with_participants flag)
- Version bumped 1.3.5 → 1.3.6

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>