### PR TITLE
feat: LocationBenchmark model and gap calculation helper (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to stockmgr are documented here. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.3.8] - 2026-04-21
+### Added
+- `LocationBenchmark` SQLModel table for per-location benchmark overrides (#128)
+- `sync_location_benchmarks()` in `app/benchmark_seed.py`: ensures every active `BenchmarkItem` has a `LocationBenchmark` row for every `LocationPlan` location; called at startup via lifespan (#128)
+- `app/gap_utils.py`: `get_target_qty()` helper — calculates target stock quantity respecting per-location overrides, enable/disable flag, and participant scaling (#128)
+- Tests in `tests/test_location_benchmark.py` covering scaling, overrides, disabled items, sync creation and idempotency (#128)
+
 ## [1.3.7] - 2026-04-21
 ### Added
 - Benchmark management UI at `/benchmark` (admin only) (#127)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stockmgr
 
-![version](https://img.shields.io/badge/version-1.3.7-blue)
+![version](https://img.shields.io/badge/version-1.3.8-blue)
 
 
 Web MVP to manage SHTF stock inventorywith OAuth-capable authentication, barcode-assisted item entry, CSV/XLSX import, renewal-date calendar sync, and configurable product-information providers.

--- a/app/benchmark_seed.py
+++ b/app/benchmark_seed.py
@@ -5,6 +5,37 @@ from app.models import BenchmarkItem
 from sqlmodel import Session, select
 
 
+def sync_location_benchmarks(session: Session) -> int:
+    """Ensure every active BenchmarkItem has a LocationBenchmark row for every LocationPlan location.
+
+    Creates missing rows with is_enabled=True, no override. Returns count of rows created.
+    """
+    from app.models import LocationBenchmark, LocationPlan  # noqa: PLC0415
+
+    locations = session.exec(select(LocationPlan)).all()
+    active_items = session.exec(select(BenchmarkItem).where(BenchmarkItem.is_active == True)).all()  # noqa: E712
+    created = 0
+    for loc in locations:
+        for item in active_items:
+            exists = session.exec(
+                select(LocationBenchmark).where(
+                    LocationBenchmark.location == loc.location,
+                    LocationBenchmark.benchmark_item_id == item.id,
+                )
+            ).first()
+            if not exists:
+                session.add(LocationBenchmark(
+                    location=loc.location,
+                    benchmark_item_id=item.id,
+                    is_enabled=True,
+                    qty_override=None,
+                ))
+                created += 1
+    if created:
+        session.commit()
+    return created
+
+
 def seed_benchmark_if_empty(session: Session) -> int:
     """Insert benchmark items if the table is empty. Returns count inserted."""
     existing = session.exec(select(BenchmarkItem)).first()

--- a/app/gap_utils.py
+++ b/app/gap_utils.py
@@ -1,0 +1,28 @@
+"""Gap analysis calculation helpers."""
+from __future__ import annotations
+
+from app.models import BenchmarkItem, LocationBenchmark
+
+
+def get_target_qty(
+    benchmark_item: BenchmarkItem,
+    location_override: LocationBenchmark | None,
+    participants: int,
+    stock_duration_days: int,
+) -> float:
+    """Calculate target quantity for a benchmark item at a location.
+
+    Returns 0.0 if the item is disabled for the location.
+    Uses qty_override if set, otherwise uses benchmark_item.qty_per_day.
+    Scales by participants if benchmark_item.scales_with_participants is True.
+    """
+    if location_override is not None and not location_override.is_enabled:
+        return 0.0
+    qty_per_day = (
+        location_override.qty_override
+        if (location_override and location_override.qty_override is not None)
+        else benchmark_item.qty_per_day
+    )
+    if benchmark_item.scales_with_participants:
+        return qty_per_day * participants * stock_duration_days
+    return qty_per_day * stock_duration_days

--- a/app/main.py
+++ b/app/main.py
@@ -83,6 +83,11 @@ async def lifespan(_: FastAPI):
         count = seed_benchmark_if_empty(session)
         if count:
             logger.info("Seeded %d benchmark items", count)
+    from app.benchmark_seed import sync_location_benchmarks  # noqa: PLC0415
+    with Session(engine) as session:
+        synced = sync_location_benchmarks(session)
+        if synced:
+            logger.info("Synced %d new location benchmark rows", synced)
     yield
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -100,3 +100,15 @@ class BenchmarkItem(SQLModel, table=True):
     is_active: bool = Field(default=True)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class LocationBenchmark(SQLModel, table=True):
+    """Per-location overrides for benchmark items."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    location: str = Field(index=True, nullable=False)
+    benchmark_item_id: int = Field(index=True, nullable=False)
+    is_enabled: bool = Field(default=True)
+    qty_override: float | None = Field(default=None)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/app/version.py
+++ b/app/version.py
@@ -1,5 +1,5 @@
 """Application version constants. Update APP_VERSION on every release."""
 
-APP_VERSION = "1.3.7"
+APP_VERSION = "1.3.8"
 BUILD_DATE = "2026-04-21"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockmgr"
-version = "1.3.7"
+version = "1.3.8"
 description = "SHTF stock inventory management web application"
 requires-python = ">=3.12"
 

--- a/tests/test_location_benchmark.py
+++ b/tests/test_location_benchmark.py
@@ -1,0 +1,129 @@
+"""Tests for LocationBenchmark model, sync helper, and gap calculation."""
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.benchmark_seed import sync_location_benchmarks
+from app.gap_utils import get_target_qty
+from app.models import BenchmarkItem, LocationBenchmark, LocationPlan
+
+
+@pytest.fixture()
+def mem_engine():
+    """In-memory SQLite engine with all tables created fresh."""
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    SQLModel.metadata.drop_all(engine)
+
+
+def _make_item(**kwargs) -> BenchmarkItem:
+    defaults = dict(
+        name="Test Item",
+        name_pt="Item de Teste",
+        item_category="food",
+        qty_per_day=1.0,
+        uom="kg",
+        scales_with_participants=True,
+        is_active=True,
+        sort_order=0,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    defaults.update(kwargs)
+    return BenchmarkItem(**defaults)
+
+
+def _make_location_plan(location: str, participants: int = 2, days: int = 7) -> LocationPlan:
+    return LocationPlan(
+        location=location,
+        participants=participants,
+        stock_duration_days=days,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+# ── get_target_qty tests ────────────────────────────────────────────────────
+
+
+def test_get_target_qty_scales_with_participants():
+    item = _make_item(qty_per_day=2.0, scales_with_participants=True)
+    result = get_target_qty(item, None, participants=3, stock_duration_days=7)
+    assert result == 42.0  # 2.0 × 3 × 7
+
+
+def test_get_target_qty_no_scaling():
+    item = _make_item(qty_per_day=0.3, scales_with_participants=False)
+    result = get_target_qty(item, None, participants=3, stock_duration_days=7)
+    assert pytest.approx(result) == 2.1  # 0.3 × 7
+
+
+def test_get_target_qty_with_override():
+    item = _make_item(qty_per_day=2.0, scales_with_participants=True)
+    override = LocationBenchmark(
+        location="A",
+        benchmark_item_id=1,
+        is_enabled=True,
+        qty_override=1.0,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    result = get_target_qty(item, override, participants=2, stock_duration_days=7)
+    assert result == 14.0  # 1.0 × 2 × 7
+
+
+def test_get_target_qty_disabled():
+    item = _make_item(qty_per_day=2.0)
+    override = LocationBenchmark(
+        location="A",
+        benchmark_item_id=1,
+        is_enabled=False,
+        qty_override=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    result = get_target_qty(item, override, participants=3, stock_duration_days=7)
+    assert result == 0.0
+
+
+# ── sync_location_benchmarks tests ─────────────────────────────────────────
+
+
+def test_sync_creates_location_benchmark_rows(mem_engine):
+    with Session(mem_engine) as session:
+        session.add(_make_location_plan("loc-A"))
+        session.add(_make_location_plan("loc-B"))
+        for i in range(3):
+            session.add(_make_item(name=f"Item {i}", name_pt=f"Item PT {i}", sort_order=i))
+        session.commit()
+
+        created = sync_location_benchmarks(session)
+
+        all_rows = session.exec(select(LocationBenchmark)).all()
+    assert created == 6  # 2 locations × 3 items
+    assert len(all_rows) == 6
+
+
+def test_sync_is_idempotent(mem_engine):
+    with Session(mem_engine) as session:
+        session.add(_make_location_plan("loc-A"))
+        session.add(_make_location_plan("loc-B"))
+        for i in range(3):
+            session.add(_make_item(name=f"Item {i}", name_pt=f"Item PT {i}", sort_order=i))
+        session.commit()
+
+        first = sync_location_benchmarks(session)
+        second = sync_location_benchmarks(session)
+
+        all_rows = session.exec(select(LocationBenchmark)).all()
+    assert first == 6
+    assert second == 0
+    assert len(all_rows) == 6


### PR DESCRIPTION
Implements #128

## Changes
- LocationBenchmark SQLModel table for per-location benchmark overrides (plain int/str fields, no FK constraints)
- sync_location_benchmarks() in pp/benchmark_seed.py — ensures every active BenchmarkItem has a row for every LocationPlan location; called at startup via lifespan
- pp/gap_utils.py — get_target_qty() helper with override, disable, and participant-scaling logic
- 6 new tests in 	ests/test_location_benchmark.py (all passing)
- Version bump 1.3.7 → 1.3.8

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>