### PR TITLE
feat: non-food support in shopping list and renewals (#132, #133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to stockmgr are documented here. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.4.2] - 2026-04-22
+### Added
+- Shopping list now includes non-food items with unmet `target_unidoses_location` (#132)
+- `item_category` and `non_food_category` added to shopping list query grouping (#132)
+- Category badge (medicine, energy, tools, hygiene, seeds, communication, security) shown for non-food items in shopping list (#132)
+- `data-category` attribute on shopping list `<tr>` rows for client-side filtering (#132)
+- Client-side category filter (All / Food / Non-food) on shopping list page (#132)
+- `data-category` attribute on renewals `<tr>` rows (#133)
+- Category badge for non-food items in renewals list (#133)
+- Client-side category filter on renewals page (#133)
+- i18n keys: `shopping.non_food_section`, `shopping.food_section`, `shopping.category`, `renewals.category_filter` (EN + PT)
+
 ## [1.4.1] - 2026-04-22
 ### Added
 - `data-category` and `data-nfc` attributes on inventory list `<tr>` rows (#131)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stockmgr
 
-![version](https://img.shields.io/badge/version-1.4.1-blue)
+![version](https://img.shields.io/badge/version-1.4.2-blue)
 
 
 Web MVP to manage SHTF stock inventorywith OAuth-capable authentication, barcode-assisted item entry, CSV/XLSX import, renewal-date calendar sync, and configurable product-information providers.

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -174,6 +174,9 @@ TRANSLATIONS = {
         "shopping.total_to_buy": "Total quantity to buy",
         "shopping.distribution": "Location distribution",
         "shopping.no_items": "No items to buy.",
+        "shopping.non_food_section": "Non-food Items",
+        "shopping.food_section": "Food Items",
+        "shopping.category": "Category",
         "device.title": "Device Compatibility Check",
         "device.subtitle": (
             "Use this page on each phone/browser to validate camera and PWA support."
@@ -196,6 +199,7 @@ TRANSLATIONS = {
         "renewal.filter_location": "Location",
         "renewal.all_locations": "All locations",
         "renewal.print": "Print / PDF",
+        "renewals.category_filter": "Category",
         "product.batches": "Stock by location",
         "product.details_title": "Product details",
         "product.edit_details": "Edit product details",
@@ -563,6 +567,9 @@ TRANSLATIONS = {
         "shopping.total_to_buy": "Quantidade total a comprar",
         "shopping.distribution": "Distribuicao por localizacao",
         "shopping.no_items": "Sem itens para comprar.",
+        "shopping.non_food_section": "Itens Não-alimentares",
+        "shopping.food_section": "Itens Alimentares",
+        "shopping.category": "Categoria",
         "device.title": "Diagnostico de Compatibilidade do Dispositivo",
         "device.subtitle": (
             "Use esta pagina em cada telemovel/navegador para validar camera e suporte PWA."
@@ -585,6 +592,7 @@ TRANSLATIONS = {
         "renewal.filter_location": "Localização",
         "renewal.all_locations": "Todas as localizações",
         "renewal.print": "Imprimir / PDF",
+        "renewals.category_filter": "Categoria",
         "product.batches": "Stock por localização",
         "product.details_title": "Detalhes do produto",
         "product.edit_details": "Editar detalhes do produto",

--- a/app/main.py
+++ b/app/main.py
@@ -1229,17 +1229,25 @@ def shopping_list(request: Request, session: Session = Depends(get_session)):
             StockItem.item_type,
             StockItem.storage_location,
             StockItem.food_group,
+            StockItem.item_category,
+            StockItem.non_food_category,
             func.sum(StockItem.quantity * StockItem.unidose_per_pack).label("total_unidoses"),
             func.max(StockItem.target_unidoses_location).label("target_unidoses"),
             func.max(StockItem.unidose_per_pack).label("unidose_per_pack"),
         )
-        .group_by(StockItem.name, StockItem.item_type, StockItem.storage_location)
+        .group_by(
+            StockItem.name,
+            StockItem.item_type,
+            StockItem.storage_location,
+            StockItem.item_category,
+            StockItem.non_food_category,
+        )
         .order_by(StockItem.name, StockItem.storage_location)
     ).all()
 
     grouped: dict[tuple[str, str], dict[str, Any]] = {}
     for row in location_rows:
-        name, item_type, location, food_group, total_u, target_u, per_pack = row
+        name, item_type, location, food_group, item_category, non_food_category, total_u, target_u, per_pack = row
         total_unidoses = int(total_u or 0)
         per_pack_value = max(1, int(per_pack or 1))
 
@@ -1264,6 +1272,8 @@ def shopping_list(request: Request, session: Session = Depends(get_session)):
                 "item_type": item_type,
                 "food_group": food_group,
                 "food_group_color": fg_obj.color if fg_obj else None,
+                "item_category": item_category or "food",
+                "non_food_category": non_food_category,
                 "total_quantity_to_buy": 0,
                 "distribution": [],
             }

--- a/app/templates/renewals.html
+++ b/app/templates/renewals.html
@@ -18,6 +18,14 @@
       {% endfor %}
     </select>
   </div>
+  <div class="col-md-3">
+    <label class="form-label">{{ t("renewals.category_filter") }}</label>
+    <select class="form-select" id="renewal-cat-filter" onchange="filterRenewalCategory(this.value)">
+      <option value="">{{ t("filter.all") }}</option>
+      <option value="food">{{ t("category.food") }}</option>
+      <option value="non_food">{{ t("category.non_food") }}</option>
+    </select>
+  </div>
   <div class="col-md-2 d-flex align-items-end">
     <button class="btn btn-primary w-100" type="submit">{{ t("renewal.apply") }}</button>
   </div>
@@ -39,11 +47,17 @@
       </thead>
       <tbody>
         {% for item in rows %}
-        <tr>
+        <tr data-category="{{ item.item_category or 'food' }}">
           <td>
             <a class="text-decoration-none item-link" href="/products/by-name/{{ item.item_type | urlencode_path }}/{{ item.name | urlencode_path }}" data-product-name="{{ item.name }}" data-product-image="{{ item.image_url or '' }}">{{ item.name }}</a>
             {% if item.nutriscore %}<span class="badge ms-1 nutriscore-badge" style="background:var(--bs-{% if item.nutriscore in ['a','b'] %}success{% elif item.nutriscore == 'c' %}warning{% elif item.nutriscore == 'd' %}danger{% else %}secondary{% endif %});" data-bs-toggle="tooltip" title="Nutri-score {{ item.nutriscore | upper }}">{{ item.nutriscore | upper }}</span>{% endif %}
             {% if item.food_group and food_groups_map.get(item.food_group) %}{% set fg = food_groups_map[item.food_group] %}<span class="d-inline-block rounded-circle border border-white ms-1" style="width:12px;height:12px;background:{{ fg.color }};vertical-align:middle;" data-bs-toggle="tooltip" title="{{ fg.name_en }}"></span>{% endif %}
+            {% if item.item_category == "non_food" %}
+              {% if item.non_food_category == "medicine" %}<span class="badge badge-medicine ms-1">💊</span>
+              {% elif item.non_food_category == "energy" %}<span class="badge badge-energy ms-1">⛽</span>
+              {% elif item.non_food_category == "seeds" %}<span class="badge badge-seeds ms-1">🌱</span>
+              {% else %}<span class="badge badge-other ms-1">📦</span>{% endif %}
+            {% endif %}
           </td>
           <td>{{ item.item_type }}</td>
           <td>{{ item.batch_code or "-" }}</td>
@@ -63,4 +77,12 @@
 </div>
 
 {% endblock %}
+
+<script>
+function filterRenewalCategory(val) {
+  document.querySelectorAll('[data-enhanced-table] tbody tr[data-category]').forEach(function(tr) {
+    tr.style.display = (!val || tr.dataset.category === val) ? '' : 'none';
+  });
+}
+</script>
 

--- a/app/templates/shopping_list.html
+++ b/app/templates/shopping_list.html
@@ -2,6 +2,15 @@
 {% block content %}
 <h1 class="h4 mb-3">{{ t("shopping.title") }}</h1>
 
+<div class="mb-3 d-flex align-items-center gap-2">
+  <label class="form-label mb-0">{{ t("filter.category") }}:</label>
+  <select class="form-select form-select-sm w-auto" onchange="filterByCategory(this.value)">
+    <option value="">{{ t("filter.all") }}</option>
+    <option value="food">{{ t("category.food") }}</option>
+    <option value="non_food">{{ t("category.non_food") }}</option>
+  </select>
+</div>
+
 <div class="card">
   <div class="table-responsive">
     <table class="table table-striped mb-0" data-enhanced-table>
@@ -15,10 +24,20 @@
       </thead>
       <tbody>
         {% for row in rows %}
-        <tr>
+        <tr data-category="{{ row.item_category or 'food' }}">
           <td>
             <a class="text-decoration-none item-link" href="/products/by-name/{{ row.item_type | urlencode_path }}/{{ row.name | urlencode_path }}" data-product-name="{{ row.name }}" data-product-image="{{ row.image_url or '' }}">{{ row.name }}</a>
             {% if row.food_group and food_groups_map.get(row.food_group) %}{% set fg = food_groups_map[row.food_group] %}<span class="d-inline-block rounded-circle border border-white ms-1" style="width:12px;height:12px;background:{{ fg.color }};vertical-align:middle;" data-bs-toggle="tooltip" title="{{ fg.name_en }}"></span>{% endif %}
+            {% if row.item_category == "non_food" %}
+              {% if row.non_food_category == "medicine" %}<span class="badge badge-medicine ms-1">💊 {{ t('badge.medicine') }}</span>
+              {% elif row.non_food_category == "energy" %}<span class="badge badge-energy ms-1">⛽ {{ t('badge.energy') }}</span>
+              {% elif row.non_food_category == "tools" %}<span class="badge badge-tools ms-1">🔧 {{ t('badge.tools') }}</span>
+              {% elif row.non_food_category == "hygiene" %}<span class="badge badge-hygiene ms-1">🧼 {{ t('badge.hygiene') }}</span>
+              {% elif row.non_food_category == "seeds" %}<span class="badge badge-seeds ms-1">🌱 {{ t('badge.seeds') }}</span>
+              {% elif row.non_food_category == "communication" %}<span class="badge badge-communication ms-1">📻 {{ t('badge.communication') }}</span>
+              {% elif row.non_food_category == "security" %}<span class="badge badge-security ms-1">🛡️ {{ t('badge.security') }}</span>
+              {% else %}<span class="badge badge-other ms-1">📦 {{ t('badge.other') }}</span>{% endif %}
+            {% endif %}
           </td>
           <td>{{ row.item_type }}</td>
           <td>{{ row.total_quantity_to_buy }}</td>
@@ -33,5 +52,13 @@
     </table>
   </div>
 </div>
+
+<script>
+function filterByCategory(val) {
+  document.querySelectorAll('[data-enhanced-table] tbody tr[data-category]').forEach(function(tr) {
+    tr.style.display = (!val || tr.dataset.category === val) ? '' : 'none';
+  });
+}
+</script>
 {% endblock %}
 

--- a/app/version.py
+++ b/app/version.py
@@ -1,5 +1,5 @@
 """Application version constants. Update APP_VERSION on every release."""
 
-APP_VERSION = "1.4.1"
+APP_VERSION = "1.4.2"
 BUILD_DATE = "2026-04-21"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockmgr"
-version = "1.4.1"
+version = "1.4.2"
 description = "SHTF stock inventory management web application"
 requires-python = ">=3.12"
 

--- a/tests/test_renewals_nonfood.py
+++ b/tests/test_renewals_nonfood.py
@@ -1,0 +1,74 @@
+"""Tests for correct expiry filtering for non-food items in renewals (#133)."""
+from datetime import date, timedelta
+
+
+def _create_tool_item(client, name="Shovel"):
+    """Tools have no expiry_date."""
+    client.post(
+        "/items",
+        data={
+            "name": name,
+            "item_type": "tools",
+            "item_category": "non_food",
+            "non_food_category": "tools",
+            "storage_location": "Shed",
+            "quantity": "1",
+            "unidose_per_pack": "1",
+        },
+        follow_redirects=False,
+    )
+
+
+def _create_food_item_expiring_soon(client, name="Canned Peas", days=15):
+    expiry = (date.today() + timedelta(days=days)).isoformat()
+    client.post(
+        "/items",
+        data={
+            "name": name,
+            "item_type": "legumes",
+            "item_category": "food",
+            "storage_location": "Pantry",
+            "expiry_date": expiry,
+            "quantity": "2",
+            "unidose_per_pack": "1",
+        },
+        follow_redirects=False,
+    )
+
+
+def _create_medicine_item_expiring_soon(client, name="Aspirin", days=15):
+    expiry = (date.today() + timedelta(days=days)).isoformat()
+    client.post(
+        "/items",
+        data={
+            "name": name,
+            "item_type": "medicine",
+            "item_category": "non_food",
+            "non_food_category": "medicine",
+            "storage_location": "Medicine Cabinet",
+            "expiry_date": expiry,
+            "quantity": "1",
+            "unidose_per_pack": "1",
+        },
+        follow_redirects=False,
+    )
+
+
+def test_renewals_excludes_null_expiry_items(client):
+    """Tools (no expiry) do not appear in renewals; food with expiry does."""
+    _create_tool_item(client, name="Unique Shovel 99")
+    _create_food_item_expiring_soon(client, name="Unique Peas 99", days=15)
+
+    resp = client.get("/renewals?days=30")
+    assert resp.status_code == 200
+    assert "Unique Shovel 99" not in resp.text
+    assert "Unique Peas 99" in resp.text
+
+
+def test_renewals_includes_medicine_with_expiry(client):
+    """Medicine items with an expiry date within the window appear in renewals."""
+    _create_medicine_item_expiring_soon(client, name="Unique Aspirin 77", days=15)
+
+    resp = client.get("/renewals?days=30")
+    assert resp.status_code == 200
+    assert "Unique Aspirin 77" in resp.text

--- a/tests/test_shopping_list_nonfood.py
+++ b/tests/test_shopping_list_nonfood.py
@@ -1,0 +1,57 @@
+"""Tests for non-food item support in shopping list (#132)."""
+from datetime import date, timedelta
+
+
+def _create_tool_item(client, name="Hammer", target=5):
+    client.post(
+        "/items",
+        data={
+            "name": name,
+            "item_type": "tools",
+            "item_category": "non_food",
+            "non_food_category": "tools",
+            "storage_location": "Garage",
+            "quantity": "0",
+            "unidose_per_pack": "1",
+            "target_unidoses_location": str(target),
+        },
+        follow_redirects=False,
+    )
+
+
+def _create_food_item(client, name="Canned Soup", target=5):
+    expiry = (date.today() + timedelta(days=365)).isoformat()
+    client.post(
+        "/items",
+        data={
+            "name": name,
+            "item_type": "legumes",
+            "item_category": "food",
+            "storage_location": "Pantry",
+            "expiry_date": expiry,
+            "quantity": "0",
+            "unidose_per_pack": "1",
+            "target_unidoses_location": str(target),
+        },
+        follow_redirects=False,
+    )
+
+
+def test_shopping_list_includes_nonfood_items(client):
+    """Non-food items with unmet targets appear in the shopping list."""
+    _create_tool_item(client, name="Hammer 5lb", target=5)
+
+    resp = client.get("/shopping-list")
+    assert resp.status_code == 200
+    assert "Hammer 5lb" in resp.text
+
+
+def test_shopping_list_has_data_category_attribute(client):
+    """Shopping list rows carry data-category for food and non_food items."""
+    _create_food_item(client, name="Canned Soup X", target=5)
+    _create_tool_item(client, name="Wrench 10mm", target=3)
+
+    resp = client.get("/shopping-list")
+    assert resp.status_code == 200
+    assert 'data-category="food"' in resp.text
+    assert 'data-category="non_food"' in resp.text


### PR DESCRIPTION
Implements #132 and #133

## Changes
- Shopping list includes non-food items with unmet targets
- Category badges and data-category attribute on shopping list rows
- Client-side category filter (All / Food / Non-food) on shopping list
- Category badges and data-category attribute on renewals rows  
- Client-side category filter on renewals page
- Renewals query already had xpiry_date IS NOT NULL — confirmed correct
- i18n keys added for EN + PT
- Version bumped 1.4.1 → 1.4.2
- 4 new tests (157 total, all passing)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>