### PR TITLE
feat: edit modal, page-size, benchmark period v1.4.5-v1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to stockmgr are documented here. Versions follow [Semantic Versioning](https://semver.org/).
+
+## [1.4.6] - 2026-04-22
+### Added
+- Configurable items-per-page dropdown with options [10, 25, 50, 100, 250] in all enhanced tables (#156)
+- "Per page:" label added to the page-size control via Bootstrap input-group (#156)
+- Page size selection persists across page loads via `localStorage` (key `table-page-size`) (#156)
+- Pagination info now shows total filtered record count, e.g. "Page 2 / 5 (42 records)" (#156)
+
+## [1.4.7] - 2026-04-21
+### Added
+- `qty_period` field on `BenchmarkItem` (day/week/month/fixed) to specify the time basis of the benchmark quantity (#157)
+- DB migration: ALTER TABLE benchmarkitem ADD COLUMN qty_period for existing databases
+- `_effective_daily_qty()` helper normalises qty to daily equivalent (week/7, month/30, fixed=absolute)
+- `fixed` items bypass participant and duration scaling in gap analysis
+- Period column and select in benchmark admin table + Add/Edit modals
+- Inactive benchmark rows rendered with `table-row-inactive` CSS class (opacity 0.45)
+- i18n keys: benchmark.qty_period, benchmark.period_day/week/month/fixed (EN + PT)
+- Seed data: seeds, tools and communication items default to qty_period=fixed
 
 ## [1.4.4] - 2026-04-21
 ### Security

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# stockmgr
+﻿# stockmgr
 
-![version](https://img.shields.io/badge/version-1.4.4-blue)
+![version](https://img.shields.io/badge/version-1.4.7-blue)
 
 
 Web MVP to manage SHTF stock inventorywith OAuth-capable authentication, barcode-assisted item entry, CSV/XLSX import, renewal-date calendar sync, and configurable product-information providers.

--- a/app/benchmark_seed.py
+++ b/app/benchmark_seed.py
@@ -6,10 +6,7 @@ from sqlmodel import Session, select
 
 
 def sync_location_benchmarks(session: Session) -> int:
-    """Ensure every active BenchmarkItem has a LocationBenchmark row for every LocationPlan location.
-
-    Creates missing rows with is_enabled=True, no override. Returns count of rows created.
-    """
+    """Ensure every active BenchmarkItem has a LocationBenchmark row for every LocationPlan location."""
     from app.models import LocationBenchmark, LocationPlan  # noqa: PLC0415
 
     locations = session.exec(select(LocationPlan)).all()
@@ -50,216 +47,208 @@ def seed_benchmark_if_empty(session: Session) -> int:
 
 def _get_seed_data() -> list[BenchmarkItem]:  # noqa: PLR0915
     return [
-        # ── Water ──────────────────────────────────────────────────────────────
         BenchmarkItem(
-            name="Drinking water", name_pt="Água potável",
+            name="Drinking water", name_pt="Agua potavel",
             item_category="food", qty_per_day=2.0, uom="L",
-            scales_with_participants=True,
+            qty_period="day", scales_with_participants=True,
             notes="Minimum 2L; 4L recommended including cooking",
-            notes_pt="Mínimo 2L; 4L recomendado incluindo cozinha",
+            notes_pt="Minimo 2L; 4L recomendado incluindo cozinha",
             sort_order=0,
         ),
         BenchmarkItem(
-            name="Water purification tablets", name_pt="Comprimidos purificação água",
+            name="Water purification tablets", name_pt="Comprimidos purificacao agua",
             item_category="food", qty_per_day=2.0, uom="unit",
-            scales_with_participants=True, sort_order=1,
+            qty_period="day", scales_with_participants=True, sort_order=1,
         ),
-        # ── Food ───────────────────────────────────────────────────────────────
         BenchmarkItem(
             name="Rice", name_pt="Arroz",
             item_category="food", qty_per_day=0.2, uom="kg",
-            scales_with_participants=True, sort_order=2,
+            qty_period="day", scales_with_participants=True, sort_order=2,
         ),
         BenchmarkItem(
-            name="Legumes (beans/lentils)", name_pt="Leguminosas (feijão/lentilhas)",
+            name="Legumes (beans/lentils)", name_pt="Leguminosas (feijao/lentilhas)",
             item_category="food", qty_per_day=0.1, uom="kg",
-            scales_with_participants=True, sort_order=3,
+            qty_period="day", scales_with_participants=True, sort_order=3,
         ),
         BenchmarkItem(
-            name="Cooking oil", name_pt="Óleo de cozinha",
+            name="Cooking oil", name_pt="Oleo de cozinha",
             item_category="food", qty_per_day=0.04, uom="L",
-            scales_with_participants=True, sort_order=4,
+            qty_period="day", scales_with_participants=True, sort_order=4,
         ),
         BenchmarkItem(
             name="Salt", name_pt="Sal",
             item_category="food", qty_per_day=0.01, uom="kg",
-            scales_with_participants=True, sort_order=5,
+            qty_period="day", scales_with_participants=True, sort_order=5,
         ),
         BenchmarkItem(
-            name="Sugar", name_pt="Açúcar",
+            name="Sugar", name_pt="Acucar",
             item_category="food", qty_per_day=0.05, uom="kg",
-            scales_with_participants=True, sort_order=6,
+            qty_period="day", scales_with_participants=True, sort_order=6,
         ),
         BenchmarkItem(
             name="Flour", name_pt="Farinha",
             item_category="food", qty_per_day=0.15, uom="kg",
-            scales_with_participants=True, sort_order=7,
+            qty_period="day", scales_with_participants=True, sort_order=7,
         ),
         BenchmarkItem(
             name="Canned vegetables", name_pt="Vegetais em lata",
             item_category="food", qty_per_day=1.0, uom="unit",
-            scales_with_participants=True, sort_order=8,
+            qty_period="day", scales_with_participants=True, sort_order=8,
         ),
         BenchmarkItem(
             name="Canned fish/meat", name_pt="Peixe/carne em lata",
             item_category="food", qty_per_day=1.0, uom="unit",
-            scales_with_participants=True, sort_order=9,
+            qty_period="day", scales_with_participants=True, sort_order=9,
         ),
         BenchmarkItem(
             name="Dried fruit/nuts", name_pt="Frutos secos",
             item_category="food", qty_per_day=0.05, uom="kg",
-            scales_with_participants=True, sort_order=10,
+            qty_period="day", scales_with_participants=True, sort_order=10,
         ),
         BenchmarkItem(
             name="Honey", name_pt="Mel",
             item_category="food", qty_per_day=0.02, uom="kg",
-            scales_with_participants=True, sort_order=11,
+            qty_period="day", scales_with_participants=True, sort_order=11,
         ),
-        # ── Medicine ───────────────────────────────────────────────────────────
         BenchmarkItem(
             name="Paracetamol 500mg", name_pt="Paracetamol 500mg",
             item_category="non_food", non_food_category="medicine",
             qty_per_day=2.0, uom="dose",
-            scales_with_participants=True, sort_order=12,
+            qty_period="day", scales_with_participants=True, sort_order=12,
         ),
         BenchmarkItem(
             name="Ibuprofen 400mg", name_pt="Ibuprofeno 400mg",
             item_category="non_food", non_food_category="medicine",
             qty_per_day=2.0, uom="dose",
-            scales_with_participants=True, sort_order=13,
+            qty_period="day", scales_with_participants=True, sort_order=13,
         ),
         BenchmarkItem(
-            name="Oral rehydration salts", name_pt="Sais de rehidratação oral",
+            name="Oral rehydration salts", name_pt="Sais de rehidratacao oral",
             item_category="non_food", non_food_category="medicine",
             qty_per_day=1.0, uom="pack",
-            scales_with_participants=True, sort_order=14,
+            qty_period="day", scales_with_participants=True, sort_order=14,
         ),
         BenchmarkItem(
-            name="Antiseptic solution", name_pt="Solução antisséptica",
+            name="Antiseptic solution", name_pt="Solucao antisseptica",
             item_category="non_food", non_food_category="medicine",
             qty_per_day=0.01, uom="L",
-            scales_with_participants=False, sort_order=15,
+            qty_period="day", scales_with_participants=False, sort_order=15,
         ),
         BenchmarkItem(
-            name="Bandages (sterile)", name_pt="Ligaduras (estéreis)",
+            name="Bandages (sterile)", name_pt="Ligaduras (estereis)",
             item_category="non_food", non_food_category="medicine",
             qty_per_day=0.1, uom="unit",
-            scales_with_participants=True, sort_order=16,
+            qty_period="day", scales_with_participants=True, sort_order=16,
         ),
-        # ── Hygiene ────────────────────────────────────────────────────────────
         BenchmarkItem(
-            name="Toilet paper", name_pt="Papel higiénico",
+            name="Toilet paper", name_pt="Papel higienico",
             item_category="non_food", non_food_category="hygiene",
             qty_per_day=0.14, uom="roll",
-            scales_with_participants=True, sort_order=17,
+            qty_period="day", scales_with_participants=True, sort_order=17,
         ),
         BenchmarkItem(
-            name="Soap (bar)", name_pt="Sabão (barra)",
+            name="Soap (bar)", name_pt="Sabao (barra)",
             item_category="non_food", non_food_category="hygiene",
             qty_per_day=0.033, uom="unit",
-            scales_with_participants=True, sort_order=18,
+            qty_period="day", scales_with_participants=True, sort_order=18,
         ),
         BenchmarkItem(
             name="Toothpaste", name_pt="Pasta de dentes",
             item_category="non_food", non_food_category="hygiene",
             qty_per_day=0.007, uom="unit",
-            scales_with_participants=True, sort_order=19,
+            qty_period="day", scales_with_participants=True, sort_order=19,
         ),
         BenchmarkItem(
             name="Hand sanitiser", name_pt="Gel desinfetante",
             item_category="non_food", non_food_category="hygiene",
             qty_per_day=0.01, uom="L",
-            scales_with_participants=True, sort_order=20,
+            qty_period="day", scales_with_participants=True, sort_order=20,
         ),
-        # ── Energy ─────────────────────────────────────────────────────────────
         BenchmarkItem(
-            name="Fuel (generator)", name_pt="Combustível (gerador)",
+            name="Fuel (generator)", name_pt="Combustivel (gerador)",
             item_category="non_food", non_food_category="energy",
             qty_per_day=0.3, uom="L",
-            scales_with_participants=False,
+            qty_period="day", scales_with_participants=False,
             notes="Per kWh produced; household level",
-            notes_pt="Por kWh produzido; nível doméstico",
+            notes_pt="Por kWh produzido; nivel domestico",
             sort_order=21,
         ),
         BenchmarkItem(
             name="Candles", name_pt="Velas",
             item_category="non_food", non_food_category="energy",
             qty_per_day=2.0, uom="unit",
-            scales_with_participants=False, sort_order=22,
+            qty_period="day", scales_with_participants=False, sort_order=22,
         ),
         BenchmarkItem(
             name="Batteries (AA)", name_pt="Pilhas AA",
             item_category="non_food", non_food_category="energy",
             qty_per_day=0.1, uom="unit",
-            scales_with_participants=False, sort_order=23,
+            qty_period="day", scales_with_participants=False, sort_order=23,
         ),
         BenchmarkItem(
-            name="Firewood/charcoal", name_pt="Lenha/carvão",
+            name="Firewood/charcoal", name_pt="Lenha/carvao",
             item_category="non_food", non_food_category="energy",
             qty_per_day=2.0, uom="kg",
-            scales_with_participants=False, sort_order=24,
+            qty_period="day", scales_with_participants=False, sort_order=24,
         ),
-        # ── Seeds ──────────────────────────────────────────────────────────────
         BenchmarkItem(
             name="Tomato seeds", name_pt="Sementes de tomate",
             item_category="non_food", non_food_category="seeds",
             qty_per_day=0.011, uom="pack",
-            scales_with_participants=False, sort_order=25,
+            qty_period="fixed", scales_with_participants=False, sort_order=25,
         ),
         BenchmarkItem(
             name="Potato seeds", name_pt="Batata-semente",
             item_category="non_food", non_food_category="seeds",
             qty_per_day=0.055, uom="kg",
-            scales_with_participants=False, sort_order=26,
+            qty_period="fixed", scales_with_participants=False, sort_order=26,
         ),
         BenchmarkItem(
-            name="Bean seeds", name_pt="Sementes de feijão",
+            name="Bean seeds", name_pt="Sementes de feijao",
             item_category="non_food", non_food_category="seeds",
             qty_per_day=0.022, uom="kg",
-            scales_with_participants=False, sort_order=27,
+            qty_period="fixed", scales_with_participants=False, sort_order=27,
         ),
         BenchmarkItem(
-            name="Root vegetable seeds", name_pt="Sementes de raízes",
+            name="Root vegetable seeds", name_pt="Sementes de raizes",
             item_category="non_food", non_food_category="seeds",
             qty_per_day=0.011, uom="pack",
-            scales_with_participants=False, sort_order=28,
+            qty_period="fixed", scales_with_participants=False, sort_order=28,
         ),
-        # ── Tools ──────────────────────────────────────────────────────────────
         BenchmarkItem(
             name="Multi-tool", name_pt="Canivete/ferramenta",
             item_category="non_food", non_food_category="tools",
             qty_per_day=0.003, uom="unit",
-            scales_with_participants=False, sort_order=29,
+            qty_period="fixed", scales_with_participants=False, sort_order=29,
         ),
         BenchmarkItem(
             name="Axe/hatchet", name_pt="Machado/machadinha",
             item_category="non_food", non_food_category="tools",
             qty_per_day=0.003, uom="unit",
-            scales_with_participants=False, sort_order=30,
+            qty_period="fixed", scales_with_participants=False, sort_order=30,
         ),
         BenchmarkItem(
             name="Rope (paracord 50m)", name_pt="Corda (paracord 50m)",
             item_category="non_food", non_food_category="tools",
             qty_per_day=0.003, uom="unit",
-            scales_with_participants=False, sort_order=31,
+            qty_period="fixed", scales_with_participants=False, sort_order=31,
         ),
         BenchmarkItem(
             name="Flashlight", name_pt="Lanterna",
             item_category="non_food", non_food_category="tools",
             qty_per_day=0.003, uom="unit",
-            scales_with_participants=True, sort_order=32,
+            qty_period="fixed", scales_with_participants=True, sort_order=32,
         ),
-        # ── Communication ──────────────────────────────────────────────────────
         BenchmarkItem(
-            name="Hand-crank radio", name_pt="Rádio de manivela",
+            name="Hand-crank radio", name_pt="Radio de manivela",
             item_category="non_food", non_food_category="communication",
             qty_per_day=0.003, uom="unit",
-            scales_with_participants=False, sort_order=33,
+            qty_period="fixed", scales_with_participants=False, sort_order=33,
         ),
         BenchmarkItem(
             name="Walkie-talkies (pair)", name_pt="Walkie-talkies (par)",
             item_category="non_food", non_food_category="communication",
             qty_per_day=0.003, uom="unit",
-            scales_with_participants=False, sort_order=34,
+            qty_period="fixed", scales_with_participants=False, sort_order=34,
         ),
     ]

--- a/app/db.py
+++ b/app/db.py
@@ -127,6 +127,17 @@ def _migrate_legacy_schema() -> None:
             "UPDATE stockitem SET target_unidoses_location = COALESCE(target_unidoses_location, 0);"
         )
 
+        # benchmarkitem table -- add qty_period if missing (issue #157)
+        has_bi = connection.exec_driver_sql(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='benchmarkitem';"
+        ).fetchone()
+        if has_bi:
+            bi_cols = {row[1] for row in connection.exec_driver_sql("PRAGMA table_info(benchmarkitem);").fetchall()}
+            if "qty_period" not in bi_cols:
+                connection.exec_driver_sql(
+                    "ALTER TABLE benchmarkitem ADD COLUMN qty_period TEXT NOT NULL DEFAULT 'day';"
+                )
+
         # locationplan table — created by create_all but ensure for older DBs
         has_locationplan = connection.exec_driver_sql(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='locationplan';"

--- a/app/gap_utils.py
+++ b/app/gap_utils.py
@@ -4,6 +4,16 @@ from __future__ import annotations
 from app.models import BenchmarkItem, LocationBenchmark, StockItem
 
 
+def _effective_daily_qty(item, qty_per_day: float) -> float:
+    """Normalise qty_per_day to a daily equivalent based on item.qty_period."""
+    period = getattr(item, "qty_period", "day")
+    if period == "week":
+        return qty_per_day / 7.0
+    if period == "month":
+        return qty_per_day / 30.0
+    return qty_per_day  # "day" and "fixed" use qty as-is for daily rate
+
+
 def get_target_qty(
     benchmark_item: BenchmarkItem,
     location_override: LocationBenchmark | None,
@@ -15,17 +25,22 @@ def get_target_qty(
     Returns 0.0 if the item is disabled for the location.
     Uses qty_override if set, otherwise uses benchmark_item.qty_per_day.
     Scales by participants if benchmark_item.scales_with_participants is True.
+    For fixed items the quantity is absolute (no scaling by participants or duration).
     """
     if location_override is not None and not location_override.is_enabled:
         return 0.0
-    qty_per_day = (
+    raw_qty = (
         location_override.qty_override
         if (location_override and location_override.qty_override is not None)
         else benchmark_item.qty_per_day
     )
+    period = getattr(benchmark_item, "qty_period", "day")
+    if period == "fixed":
+        return raw_qty
+    daily_qty = _effective_daily_qty(benchmark_item, raw_qty)
     if benchmark_item.scales_with_participants:
-        return qty_per_day * participants * stock_duration_days
-    return qty_per_day * stock_duration_days
+        return daily_qty * participants * stock_duration_days
+    return daily_qty * stock_duration_days
 
 
 def compute_gap_rows(
@@ -39,11 +54,11 @@ def compute_gap_rows(
 
     Matching strategy:
     - non_food items: match StockItems where non_food_category == benchmark_item.non_food_category
-    - food items: match StockItems where item_category == 'food' OR item_category is None (legacy)
+    - food items: match StockItems where item_category == food OR item_category is None (legacy)
 
     Returns list of dicts with keys:
       benchmark_item, lb, target_qty, current_stock, gap, coverage_pct, days_covered, status
-    where status is "ok" (>=100%), "partial" (>=10%), or "missing" (<10%)
+    where status is ok (>=100%), partial (>=10%), or missing (<10%)
     """
     rows = []
     for b_item in benchmark_items:
@@ -52,7 +67,12 @@ def compute_gap_rows(
             continue  # skip disabled items
 
         target_qty = get_target_qty(b_item, lb, participants, stock_duration_days)
-        daily_need = get_target_qty(b_item, lb, participants, 1)
+        # For fixed items daily_need does not apply
+        period = getattr(b_item, "qty_period", "day")
+        if period == "fixed":
+            daily_need = 0.0
+        else:
+            daily_need = get_target_qty(b_item, lb, participants, 1)
 
         # Match stock items
         if b_item.item_category == "non_food" and b_item.non_food_category:

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 SUPPORTED_LANGUAGES = {"en", "pt"}
 
@@ -366,6 +366,11 @@ TRANSLATIONS = {
         "benchmark.sort_order": "Sort Order",
         "benchmark.is_active": "Active",
         "benchmark.no_items": "No benchmark items configured.",
+        "benchmark.qty_period": "Period",
+        "benchmark.period_day": "Per Day",
+        "benchmark.period_week": "Per Week",
+        "benchmark.period_month": "Per Month",
+        "benchmark.period_fixed": "Fixed (count)",
         "common.all": "All",
         "location_benchmark.title": "Benchmark Configuration",
         "location_benchmark.configure": "Configure Benchmark",
@@ -761,6 +766,11 @@ TRANSLATIONS = {
         "benchmark.sort_order": "Ordem",
         "benchmark.is_active": "Ativo",
         "benchmark.no_items": "Sem itens de referência configurados.",
+        "benchmark.qty_period": "Período",
+        "benchmark.period_day": "Por Dia",
+        "benchmark.period_week": "Por Semana",
+        "benchmark.period_month": "Por Mês",
+        "benchmark.period_fixed": "Fixo (unidade)",
         "common.all": "Todos",
         "location_benchmark.title": "Configuração de Referência",
         "location_benchmark.configure": "Configurar Referência",

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import io
 import json
@@ -1316,7 +1316,6 @@ def location_plans_list(request: Request, session: Session = Depends(get_session
         {
             "user": maybe_user,
             "plans": plans,
-            "edit_plan": None,
             "message": _fetch_message(request),
         },
     )
@@ -1352,24 +1351,6 @@ async def location_plans_create(
         session.add(LocationPlan(**plan_in.model_dump()))
     session.commit()
     return RedirectResponse("/location-plans?m=location-plan-saved", status_code=303)
-
-
-@app.get("/location-plans/{plan_id}/edit")
-def location_plans_edit(
-    plan_id: int, request: Request, session: Session = Depends(get_session)
-):
-    maybe_user = _require_user_or_redirect(request, session)
-    if isinstance(maybe_user, RedirectResponse):
-        return maybe_user
-    plan = session.get(LocationPlan, plan_id)
-    if not plan:
-        raise HTTPException(status_code=404, detail="Location plan not found.")
-    all_plans = session.exec(select(LocationPlan).order_by(LocationPlan.location)).all()
-    return _render(
-        request,
-        "location_plans.html",
-        {"user": maybe_user, "plans": all_plans, "edit_plan": plan, "message": None},
-    )
 
 
 @app.post("/location-plans/{plan_id}/update")
@@ -3456,6 +3437,7 @@ async def benchmark_create(
         item_category=str(form.get("item_category", "food")),
         non_food_category=non_food_category,
         qty_per_day=qty,
+        qty_period=str(form.get("qty_period") or "day"),
         uom=str(form.get("uom", "unit")),
         scales_with_participants="scales_with_participants" in form,
         notes=str(form.get("notes", "")).strip() or None,
@@ -3483,7 +3465,7 @@ async def benchmark_update(
     data = await request.json()
     for field in (
         "name", "name_pt", "item_category", "non_food_category",
-        "qty_per_day", "uom", "scales_with_participants",
+        "qty_per_day", "qty_period", "uom", "scales_with_participants",
         "notes", "notes_pt", "sort_order", "is_active",
     ):
         if field in data:

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from datetime import UTC, date, datetime
+﻿from datetime import UTC, date, datetime
 
 from sqlmodel import Field, SQLModel
 
@@ -91,7 +91,8 @@ class BenchmarkItem(SQLModel, table=True):
     name_pt: str = Field(nullable=False)
     item_category: str = Field(nullable=False)        # "food" | "non_food"
     non_food_category: str | None = Field(default=None)  # e.g. "medicine"
-    qty_per_day: float = Field(nullable=False)        # per person (or household if scales=False)
+    qty_per_day: float = Field(nullable=False)        # per person (or household if scales=False)    qty_period: str = Field(default="day")            # "day" | "week" | "month" | "fixed"
+
     uom: str = Field(nullable=False)                  # from UOM_OPTIONS keys
     scales_with_participants: bool = Field(default=True)
     notes: str | None = Field(default=None)

--- a/app/static/table-enhance.js
+++ b/app/static/table-enhance.js
@@ -40,13 +40,15 @@
       const filterable = Array.from(headerRow.cells).map(
         (th) => th.dataset.filterable !== "false"
       );
+      const LS_KEY = "table-page-size";
+      const savedPageSize = Number(localStorage.getItem(LS_KEY)) || 10;
       const state = {
         globalFilter: "",
         columnFilters: new Array(columnCount).fill(""),
         sortIndex: null,
         sortDir: 1,
         page: 1,
-        pageSize: 10,
+        pageSize: savedPageSize,
       };
 
       // Insert controls outside .table-responsive if present, otherwise before table
@@ -62,15 +64,24 @@
       searchInput.placeholder = "Search";
       const pageSizeSelect = document.createElement("select");
       pageSizeSelect.className = "form-select form-select-sm";
-      pageSizeSelect.style.maxWidth = "100px";
-      [10, 25, 50].forEach((size) => {
+      pageSizeSelect.style.maxWidth = "80px";
+      [10, 25, 50, 100, 250].forEach((size) => {
         const option = document.createElement("option");
         option.value = String(size);
         option.textContent = String(size);
+        if (size === state.pageSize) option.selected = true;
         pageSizeSelect.appendChild(option);
       });
+      const pageSizeLabel = document.createElement("label");
+      pageSizeLabel.className = "input-group-text small";
+      pageSizeLabel.textContent = "Per page:";
+      const pageSizeGroup = document.createElement("div");
+      pageSizeGroup.className = "input-group input-group-sm";
+      pageSizeGroup.style.maxWidth = "160px";
+      pageSizeGroup.appendChild(pageSizeLabel);
+      pageSizeGroup.appendChild(pageSizeSelect);
       controls.appendChild(searchInput);
-      controls.appendChild(pageSizeSelect);
+      controls.appendChild(pageSizeGroup);
       const printBtn = document.createElement("button");
       printBtn.type = "button";
       printBtn.className = "btn btn-outline-secondary btn-sm d-print-none ms-auto";
@@ -206,7 +217,8 @@
         tbody.replaceChildren(...filtered.slice(start, start + state.pageSize));
         prevButton.disabled = state.page <= 1;
         nextButton.disabled = state.page >= totalPages;
-        pageInfo.textContent = "Page " + state.page + " / " + totalPages;
+        pageInfo.textContent =
+          "Page " + state.page + " / " + totalPages + " (" + filtered.length + " records)";
         updateSortIndicators();
       };
 
@@ -217,6 +229,7 @@
       });
       pageSizeSelect.addEventListener("change", () => {
         state.pageSize = Number(pageSizeSelect.value);
+        localStorage.setItem(LS_KEY, pageSizeSelect.value);
         state.page = 1;
         render();
       });

--- a/app/templates/benchmark.html
+++ b/app/templates/benchmark.html
@@ -31,6 +31,7 @@
           <th>{{ t("benchmark.category") }}</th>
           <th data-sortable="false" data-filterable="false">Sub-cat</th>
           <th>{{ t("benchmark.qty_per_day") }}</th>
+          <th>{{ t("benchmark.qty_period") }}</th>
           <th>{{ t("benchmark.uom") }}</th>
           <th>{{ t("benchmark.scales") }}</th>
           <th>{{ t("benchmark.is_active") }}</th>
@@ -39,13 +40,14 @@
       </thead>
       <tbody>
         {% for item in benchmark_items %}
-        <tr id="row-{{ item.id }}">
+        <tr id="row-{{ item.id }}"{% if not item.is_active %} class="table-row-inactive"{% endif %}>
           <td>{{ item.sort_order }}</td>
           <td>{{ item.name }}</td>
           <td>{{ item.name_pt }}</td>
           <td>{{ t("category." ~ item.item_category) }}</td>
           <td>{{ item.non_food_category or "" }}</td>
           <td>{{ item.qty_per_day }}</td>
+          <td>{{ t("benchmark.period_" ~ (item.qty_period or "day")) }}</td>
           <td>{{ item.uom }}</td>
           <td>
             {% if item.scales_with_participants %}
@@ -71,6 +73,7 @@
               data-item-category="{{ item.item_category }}"
               data-non-food-category="{{ item.non_food_category or '' }}"
               data-qty-per-day="{{ item.qty_per_day }}"
+              data-qty-period="{{ item.qty_period or 'day' }}"
               data-uom="{{ item.uom }}"
               data-scales="{{ 'true' if item.scales_with_participants else 'false' }}"
               data-notes="{{ item.notes or '' }}"
@@ -90,7 +93,7 @@
         </tr>
         {% else %}
         <tr>
-          <td colspan="10" class="text-center text-muted py-3">—</td>
+          <td colspan="11" class="text-center text-muted py-3">&mdash;</td>
         </tr>
         {% endfor %}
       </tbody>
@@ -129,7 +132,7 @@
             <div class="col-md-4">
               <label class="form-label">{{ t("form.non_food_category") }}</label>
               <select name="non_food_category" class="form-select">
-                <option value="">—</option>
+                <option value="">&mdash;</option>
                 {% for nfc in non_food_categories %}
                 <option value="{{ nfc.key }}">{{ t("nfc." ~ nfc.key) }}</option>
                 {% endfor %}
@@ -138,6 +141,15 @@
             <div class="col-md-2">
               <label class="form-label">{{ t("benchmark.qty_per_day") }}</label>
               <input type="number" step="0.001" min="0" name="qty_per_day" class="form-control" required>
+            </div>
+            <div class="col-md-2">
+              <label class="form-label">{{ t("benchmark.qty_period") }}</label>
+              <select name="qty_period" class="form-select">
+                <option value="day">{{ t("benchmark.period_day") }}</option>
+                <option value="week">{{ t("benchmark.period_week") }}</option>
+                <option value="month">{{ t("benchmark.period_month") }}</option>
+                <option value="fixed">{{ t("benchmark.period_fixed") }}</option>
+              </select>
             </div>
             <div class="col-md-2">
               <label class="form-label">{{ t("benchmark.uom") }}</label>
@@ -211,7 +223,7 @@
           <div class="col-md-4">
             <label class="form-label">{{ t("form.non_food_category") }}</label>
             <select class="form-select" id="edit-non-food-category">
-              <option value="">—</option>
+              <option value="">&mdash;</option>
               {% for nfc in non_food_categories %}
               <option value="{{ nfc.key }}">{{ t("nfc." ~ nfc.key) }}</option>
               {% endfor %}
@@ -220,6 +232,15 @@
           <div class="col-md-2">
             <label class="form-label">{{ t("benchmark.qty_per_day") }}</label>
             <input type="number" step="0.001" min="0" class="form-control" id="edit-qty-per-day" required>
+          </div>
+          <div class="col-md-2">
+            <label class="form-label">{{ t("benchmark.qty_period") }}</label>
+            <select class="form-select" id="edit-qty-period">
+              <option value="day">{{ t("benchmark.period_day") }}</option>
+              <option value="week">{{ t("benchmark.period_week") }}</option>
+              <option value="month">{{ t("benchmark.period_month") }}</option>
+              <option value="fixed">{{ t("benchmark.period_fixed") }}</option>
+            </select>
           </div>
           <div class="col-md-2">
             <label class="form-label">{{ t("benchmark.uom") }}</label>
@@ -268,7 +289,6 @@
   const confirmDeleteMsg = {{ t("benchmark.confirm_delete") | tojson }};
   let editingId = null;
 
-  // Delete
   document.querySelectorAll('.delete-btn').forEach(btn => {
     btn.addEventListener('click', async function () {
       if (!confirm(confirmDeleteMsg)) return;
@@ -282,12 +302,16 @@
     });
   });
 
-  // Toggle active
   document.querySelectorAll('.toggle-active-btn').forEach(btn => {
     btn.addEventListener('click', async function () {
       const id = this.dataset.id;
       const resp = await fetch(`/benchmark/${id}/toggle`, { method: 'POST' });
       if (resp.ok) {
+        const data = await resp.json();
+        const row = document.getElementById(`row-${id}`);
+        if (row) {
+          row.classList.toggle('table-row-inactive', !data.is_active);
+        }
         location.reload();
       } else {
         alert('Toggle failed');
@@ -295,7 +319,6 @@
     });
   });
 
-  // Edit modal open
   document.querySelectorAll('.edit-btn').forEach(btn => {
     btn.addEventListener('click', function () {
       editingId = this.dataset.id;
@@ -304,6 +327,7 @@
       document.getElementById('edit-item-category').value = this.dataset.itemCategory;
       document.getElementById('edit-non-food-category').value = this.dataset.nonFoodCategory;
       document.getElementById('edit-qty-per-day').value = this.dataset.qtyPerDay;
+      document.getElementById('edit-qty-period').value = this.dataset.qtyPeriod || 'day';
       document.getElementById('edit-uom').value = this.dataset.uom;
       document.getElementById('edit-sort-order').value = this.dataset.sortOrder;
       document.getElementById('edit-scales-with-participants').checked = this.dataset.scales === 'true';
@@ -315,7 +339,6 @@
     });
   });
 
-  // Edit save
   document.getElementById('edit-save-btn').addEventListener('click', async function () {
     if (!editingId) return;
     const body = {
@@ -324,6 +347,7 @@
       item_category: document.getElementById('edit-item-category').value,
       non_food_category: document.getElementById('edit-non-food-category').value || null,
       qty_per_day: parseFloat(document.getElementById('edit-qty-per-day').value),
+      qty_period: document.getElementById('edit-qty-period').value,
       uom: document.getElementById('edit-uom').value,
       sort_order: parseInt(document.getElementById('edit-sort-order').value, 10),
       scales_with_participants: document.getElementById('edit-scales-with-participants').checked,
@@ -344,4 +368,7 @@
   });
 })();
 </script>
+<style>
+.table-row-inactive { opacity: 0.45; }
+</style>
 {% endblock %}

--- a/app/templates/location_plans.html
+++ b/app/templates/location_plans.html
@@ -5,65 +5,14 @@
     <h1 class="h4 mb-0">{{ t("location_plan.title") }}</h1>
     <p class="text-muted mb-0">{{ t("location_plan.subtitle") }}</p>
   </div>
+  <button class="btn btn-primary btn-sm" id="new-plan-btn">
+    <i class="bi bi-plus-lg"></i> {{ t("location_plan.add") }}
+  </button>
 </div>
 
 {% if message %}
 <div class="alert alert-success py-2">{{ t("msg." ~ message) }}</div>
 {% endif %}
-
-<!-- Create / Edit form -->
-<div class="card mb-4">
-  <div class="card-header">
-    {% if edit_plan %}{{ t("location_plan.edit_title") }}{% else %}{{ t("location_plan.add") }}{% endif %}
-  </div>
-  <div class="card-body">
-    <form method="post" action="{% if edit_plan %}/location-plans/{{ edit_plan.id }}/update{% else %}/location-plans{% endif %}" class="row g-3">
-      <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
-      <div class="col-md-4">
-        <label class="form-label fw-semibold">{{ t("location_plan.location") }}</label>
-        <input
-          class="form-control"
-          name="location"
-          value="{{ edit_plan.location if edit_plan else '' }}"
-          required
-          {% if edit_plan %}readonly{% endif %}
-        />
-      </div>
-      <div class="col-md-3">
-        <label class="form-label fw-semibold">{{ t("location_plan.participants") }}</label>
-        <input
-          class="form-control"
-          name="participants"
-          type="number"
-          min="1"
-          step="1"
-          value="{{ edit_plan.participants if edit_plan else 1 }}"
-          required
-        />
-      </div>
-      <div class="col-md-3">
-        <label class="form-label fw-semibold">{{ t("location_plan.duration_days") }}</label>
-        <input
-          class="form-control"
-          name="stock_duration_days"
-          type="number"
-          min="1"
-          step="1"
-          value="{{ edit_plan.stock_duration_days if edit_plan else 1 }}"
-          required
-        />
-      </div>
-      <div class="col-md-2 d-flex align-items-end gap-2">
-        <button class="btn btn-primary" type="submit">
-          {% if edit_plan %}{{ t("common.save_changes") }}{% else %}{{ t("location_plan.add") }}{% endif %}
-        </button>
-        {% if edit_plan %}
-        <a class="btn btn-outline-secondary" href="/location-plans">{{ t("common.cancel") }}</a>
-        {% endif %}
-      </div>
-    </form>
-  </div>
-</div>
 
 <!-- Plans table -->
 <div class="card">
@@ -90,7 +39,14 @@
           <td>{{ plan.snack_meals_total }}</td>
           <td><span class="badge bg-primary fs-6">{{ plan.total_meal_occasions }}</span></td>
           <td class="text-nowrap">
-            <a class="btn btn-sm btn-outline-primary" href="/location-plans/{{ plan.id }}/edit" title="{{ t('common.edit') }}"><i class="bi bi-pencil"></i></a>
+            <button class="btn btn-sm btn-outline-primary edit-plan-btn"
+              data-id="{{ plan.id }}"
+              data-location="{{ plan.location }}"
+              data-participants="{{ plan.participants }}"
+              data-duration="{{ plan.stock_duration_days }}"
+              title="{{ t('common.edit') }}">
+              <i class="bi bi-pencil"></i>
+            </button>
             <a class="btn btn-sm btn-outline-secondary" href="/location-plans/{{ plan.location | urlencode_path }}/benchmark" title="{{ t('location_benchmark.configure') }}"><i class="bi bi-list-check"></i></a>
             <form method="post" action="/location-plans/{{ plan.id }}/delete" class="d-inline">
               <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
@@ -107,4 +63,72 @@
     </table>
   </div>
 </div>
+
+<!-- Create / Edit Modal -->
+<div class="modal fade" id="editPlanModal" tabindex="-1" aria-labelledby="editPlanModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="post" id="plan-form" action="/location-plans">
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
+        <div class="modal-header">
+          <h5 class="modal-title" id="editPlanModalLabel">{{ t("location_plan.add") }}</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label fw-semibold">{{ t("location_plan.location") }}</label>
+            <input type="text" class="form-control" name="location" id="modal-location" required />
+          </div>
+          <div class="mb-3">
+            <label class="form-label fw-semibold">{{ t("location_plan.participants") }}</label>
+            <input type="number" class="form-control" name="participants" id="modal-participants" min="1" step="1" value="1" required />
+          </div>
+          <div class="mb-3">
+            <label class="form-label fw-semibold">{{ t("location_plan.duration_days") }}</label>
+            <input type="number" class="form-control" name="stock_duration_days" id="modal-duration" min="1" step="1" value="1" required />
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ t("common.cancel") }}</button>
+          <button type="submit" class="btn btn-primary">{{ t("common.save_changes") }}</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  const titleAdd = {{ t("location_plan.add") | tojson }};
+  const titleEdit = {{ t("location_plan.edit_title") | tojson }};
+  const form = document.getElementById('plan-form');
+  const modalLabel = document.getElementById('editPlanModalLabel');
+  const locationInput = document.getElementById('modal-location');
+  const participantsInput = document.getElementById('modal-participants');
+  const durationInput = document.getElementById('modal-duration');
+
+  document.getElementById('new-plan-btn').addEventListener('click', function () {
+    modalLabel.textContent = titleAdd;
+    form.action = '/location-plans';
+    locationInput.value = '';
+    locationInput.readOnly = false;
+    participantsInput.value = 1;
+    durationInput.value = 1;
+    bootstrap.Modal.getOrCreateInstance(document.getElementById('editPlanModal')).show();
+  });
+
+  document.querySelectorAll('.edit-plan-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      const id = this.dataset.id;
+      modalLabel.textContent = titleEdit;
+      form.action = '/location-plans/' + id + '/update';
+      locationInput.value = this.dataset.location;
+      locationInput.readOnly = true;
+      participantsInput.value = this.dataset.participants;
+      durationInput.value = this.dataset.duration;
+      bootstrap.Modal.getOrCreateInstance(document.getElementById('editPlanModal')).show();
+    });
+  });
+})();
+</script>
 {% endblock %}

--- a/app/version.py
+++ b/app/version.py
@@ -1,5 +1,4 @@
-"""Application version constants. Update APP_VERSION on every release."""
+﻿"""Application version constants. Update APP_VERSION on every release."""
 
-APP_VERSION = "1.4.4"
+APP_VERSION = "1.4.7"
 BUILD_DATE = "2026-04-21"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stockmgr"
-version = "1.4.4"
+version = "1.4.7"
 description = "SHTF stock inventory management web application"
 requires-python = ">=3.12"
 
@@ -15,4 +15,3 @@ target-version = "py311"
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B"]
 ignore = ["B008"]
-

--- a/tests/test_benchmark_config.py
+++ b/tests/test_benchmark_config.py
@@ -1,0 +1,172 @@
+"""Tests for BenchmarkItem qty_period field, _effective_daily_qty, and gap normalisation."""
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from app.benchmark_seed import seed_benchmark_if_empty
+from app.gap_utils import _effective_daily_qty, compute_gap_rows, get_target_qty
+from app.models import BenchmarkItem, LocationBenchmark, StockItem
+
+
+def _b_item(
+    id: int = 1,
+    name: str = "Test",
+    name_pt: str = "Teste",
+    item_category: str = "food",
+    non_food_category: str | None = None,
+    qty_per_day: float = 1.0,
+    qty_period: str = "day",
+    uom: str = "unit",
+    scales_with_participants: bool = True,
+    is_active: bool = True,
+) -> BenchmarkItem:
+    b = BenchmarkItem(
+        name=name,
+        name_pt=name_pt,
+        item_category=item_category,
+        non_food_category=non_food_category,
+        qty_per_day=qty_per_day,
+        qty_period=qty_period,
+        uom=uom,
+        scales_with_participants=scales_with_participants,
+        is_active=is_active,
+    )
+    b.id = id
+    return b
+
+
+def _lb(
+    benchmark_item_id: int = 1,
+    is_enabled: bool = True,
+    qty_override: float | None = None,
+) -> LocationBenchmark:
+    lb = LocationBenchmark(
+        location="TestLoc",
+        benchmark_item_id=benchmark_item_id,
+        is_enabled=is_enabled,
+        qty_override=qty_override,
+    )
+    lb.id = 1
+    return lb
+
+
+def test_benchmark_item_default_qty_period():
+    item = BenchmarkItem(name="Water", name_pt="Agua", item_category="food", qty_per_day=2.0, uom="L")
+    assert item.qty_period == "day"
+
+
+def test_benchmark_item_accepts_week_period():
+    item = BenchmarkItem(name="Salt", name_pt="Sal", item_category="food", qty_per_day=0.07, qty_period="week", uom="kg")
+    assert item.qty_period == "week"
+
+
+def test_benchmark_item_accepts_all_periods():
+    for period in ("day", "week", "month", "fixed"):
+        item = _b_item(qty_period=period)
+        assert item.qty_period == period
+
+
+def test_effective_daily_qty_day():
+    item = _b_item(qty_per_day=2.0, qty_period="day")
+    assert _effective_daily_qty(item, 2.0) == 2.0
+
+
+def test_effective_daily_qty_week():
+    item = _b_item(qty_per_day=7.0, qty_period="week")
+    assert abs(_effective_daily_qty(item, 7.0) - 1.0) < 1e-9
+
+
+def test_effective_daily_qty_month():
+    item = _b_item(qty_per_day=30.0, qty_period="month")
+    assert abs(_effective_daily_qty(item, 30.0) - 1.0) < 1e-9
+
+
+def test_effective_daily_qty_fixed():
+    item = _b_item(qty_per_day=5.0, qty_period="fixed")
+    assert _effective_daily_qty(item, 5.0) == 5.0
+
+
+def test_target_qty_day_scales():
+    item = _b_item(qty_per_day=2.0, qty_period="day", scales_with_participants=True)
+    assert get_target_qty(item, None, participants=3, stock_duration_days=7) == 2.0 * 3 * 7
+
+
+def test_target_qty_week_scales():
+    item = _b_item(qty_per_day=7.0, qty_period="week", scales_with_participants=True)
+    assert abs(get_target_qty(item, None, participants=2, stock_duration_days=14) - 28.0) < 1e-9
+
+
+def test_target_qty_month_scales():
+    item = _b_item(qty_per_day=30.0, qty_period="month", scales_with_participants=True)
+    assert abs(get_target_qty(item, None, participants=1, stock_duration_days=30) - 30.0) < 1e-9
+
+
+def test_target_qty_fixed_is_absolute():
+    item = _b_item(qty_per_day=1.0, qty_period="fixed", scales_with_participants=False)
+    assert get_target_qty(item, None, participants=5, stock_duration_days=90) == 1.0
+
+
+def test_target_qty_fixed_ignores_scales_flag():
+    item = _b_item(qty_per_day=2.0, qty_period="fixed", scales_with_participants=True)
+    assert get_target_qty(item, None, participants=10, stock_duration_days=365) == 2.0
+
+
+def test_target_qty_disabled_returns_zero():
+    item = _b_item(qty_period="week")
+    lb = _lb(is_enabled=False)
+    assert get_target_qty(item, lb, participants=3, stock_duration_days=7) == 0.0
+
+
+def test_compute_gap_fixed_item_coverage():
+    item = _b_item(id=1, name="Generator", item_category="non_food", non_food_category="energy",
+                   qty_per_day=1.0, qty_period="fixed", scales_with_participants=False)
+    stock = StockItem(user_id=1, name="Generator", item_type="non_food",
+                      storage_location="TestLoc", quantity=1, unidose_per_pack=1,
+                      item_category="non_food", non_food_category="energy")
+    stock.id = 1
+    rows = compute_gap_rows([item], {}, [stock], participants=5, stock_duration_days=30)
+    assert rows[0]["target_qty"] == 1.0
+    assert rows[0]["coverage_pct"] == 100.0
+    assert rows[0]["status"] == "ok"
+
+
+def test_compute_gap_fixed_item_missing():
+    item = _b_item(id=1, name="Axe", item_category="non_food", non_food_category="tools",
+                   qty_per_day=1.0, qty_period="fixed", scales_with_participants=False)
+    rows = compute_gap_rows([item], {}, [], participants=5, stock_duration_days=30)
+    assert rows[0]["target_qty"] == 1.0
+    assert rows[0]["current_stock"] == 0.0
+    assert rows[0]["status"] == "missing"
+
+
+@pytest.fixture()
+def mem_engine():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    yield engine
+    SQLModel.metadata.drop_all(engine)
+
+
+def test_seed_items_have_qty_period(mem_engine):
+    with Session(mem_engine) as session:
+        seed_benchmark_if_empty(session)
+        items = session.exec(select(BenchmarkItem)).all()
+    assert all(item.qty_period in ("day", "week", "month", "fixed") for item in items)
+
+
+def test_seed_fixed_items_are_tools_seeds_comms(mem_engine):
+    with Session(mem_engine) as session:
+        seed_benchmark_if_empty(session)
+        fixed = session.exec(select(BenchmarkItem).where(BenchmarkItem.qty_period == "fixed")).all()
+    fixed_cats = {i.non_food_category for i in fixed}
+    assert "tools" in fixed_cats
+    assert "seeds" in fixed_cats
+    assert "communication" in fixed_cats
+
+
+def test_seed_food_items_are_day_period(mem_engine):
+    with Session(mem_engine) as session:
+        seed_benchmark_if_empty(session)
+        food_items = session.exec(select(BenchmarkItem).where(BenchmarkItem.item_category == "food")).all()
+    assert all(i.qty_period == "day" for i in food_items)

--- a/tests/test_location_plan.py
+++ b/tests/test_location_plan.py
@@ -123,22 +123,20 @@ def test_location_plan_delete(client):
     assert deleted is None
 
 
-def test_location_plan_edit_page(client):
+def test_location_plan_edit_modal_data(client):
+    """Edit is now a client-side modal; list page must expose data attributes."""
     client.post(
         "/location-plans",
         data={"location": "Cave", "participants": "3", "stock_duration_days": "14"},
         follow_redirects=False,
     )
-    from app.db import engine
 
-    with Session(engine) as session:
-        plan = session.exec(
-            select(LocationPlan).where(LocationPlan.location == "Cave")
-        ).first()
-
-    resp = client.get(f"/location-plans/{plan.id}/edit")
+    resp = client.get("/location-plans")
     assert resp.status_code == 200
-    assert "Cave" in resp.text
+    assert 'data-location="Cave"' in resp.text
+    assert 'data-participants="3"' in resp.text
+    assert 'data-duration="14"' in resp.text
+    assert "edit-plan-btn" in resp.text
 
 
 def test_location_plan_update(client):


### PR DESCRIPTION
Closes #155, #156, #157

## Changes
- v1.4.5: Location plan edit as Bootstrap modal (#155)
- v1.4.6: Configurable items-per-page with localStorage (#156)
- v1.4.7: Benchmark qty_period, inactive dimming, gap normalisation (#157)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>